### PR TITLE
[AVI-148] Remove yarn as a gui dependency

### DIFF
--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "build": {
-    "beforeDevCommand": "yarn dev",
-    "beforeBuildCommand": "yarn build",
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build",
     "devPath": "http://localhost:1420",
     "distDir": "../dist",
     "withGlobalTauri": false


### PR DESCRIPTION
Yarn was never required as a real dependency for the GUI. The GUI will no longer break if trying to run without yarn installed.