### PR TITLE
Flight Computer Trigger Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bimap",
  "jeflog",
  "postcard",
  "pyo3",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 jeflog = "0.1.0"
+bimap = "0.6.3"
 postcard = { version = "^1", features = ["alloc", "experimental-derive"] }
 pyo3 = { version = "0.20.3", features = ["abi3-py38"], optional = true }
 rusqlite = { version = "0.30", optional = true }

--- a/flight/src/handler.rs
+++ b/flight/src/handler.rs
@@ -143,7 +143,6 @@ pub fn abort(shared: &SharedState) {
 
   let mut sequences = shared.sequences.lock().unwrap();
   sequences.clear();
-  sequences.insert("abort".to_owned(), thread::current().id());
   drop(sequences);
 
   sequence::run(sequence);

--- a/flight/src/state.rs
+++ b/flight/src/state.rs
@@ -134,7 +134,7 @@ fn init() -> ProgramState {
     }
   };
 
-  sequence::initialize(shared.mappings.clone());
+  sequence::initialize(shared.mappings.clone(), shared.sequences.clone());
   sequence::set_device_handler(create_device_handler(
     shared.clone(),
     command_tx,
@@ -347,15 +347,8 @@ fn run_sequence(
   sequence: Sequence,
   shared: SharedState,
 ) -> ProgramState {
-  let sequence_name = sequence.name.clone();
 
-  let thread_id = thread::spawn(|| sequence::run(sequence)).thread().id();
-
-  shared
-    .sequences
-    .lock()
-    .unwrap()
-    .insert(sequence_name, thread_id);
+  thread::spawn(|| sequence::run(sequence));
 
   ProgramState::WaitForOperator {
     server_socket,


### PR DESCRIPTION
Previously, sequences created by triggers weren't being ran by the Flight Computer. The issue was that, by default, a sequence name mapped to a thread ID was required for a sequence to continue running within a `BiHashMap` named `sequences`. Its absence meant that Flight's Finite State Machine decided to stop the sequence or an abort sequence was successfully ran. Thus, when the device handler for the triggered sequence was ran, it would immediately stop the sequence.

I fixed this by moving the responsibility to register sequences in `sequences` to `common::sequences::run()`. While giving access to the `sequences` mutex was needed, now to run a sequence all one must do is define its struct and pass the struct into `common::sequences::run()`.

I edited all references to `common::sequences::run()` to reflect this new change.