### PR TITLE
Merging Dev/AVI-206 onboard adc

### DIFF
--- a/sam/src/adc.rs
+++ b/sam/src/adc.rs
@@ -26,7 +26,6 @@ pub enum Measurement {
   Tc2,
   DiffSensors,
   Rtd,
-  Power,
 }
 
 pub enum ADCEnum {
@@ -149,7 +148,6 @@ impl ADC {
         self.write_reg(0x05, 0x0A);
       }
 
-      Measurement::Power => ()
     }
 
     // delay for at least 4000*clock period
@@ -341,8 +339,7 @@ impl ADC {
         }
         _ => fail!("Failed register write — could not mod iteration"),
       },
-
-      Measurement::Power => ()
+      
     }
   }
 

--- a/sam/src/adc.rs
+++ b/sam/src/adc.rs
@@ -89,6 +89,18 @@ impl ADC {
     }
   }
 
+  pub fn pull_cs_high_active_low(&mut self) {
+    if let Some(pin) = self.gpio_mappings.get(&self.measurement) {
+      pin.digital_write(High);
+    }
+  }
+
+  pub fn pull_cs_low_active_low(&mut self) {
+    if let Some(pin) = self.gpio_mappings.get(&self.measurement) {
+      pin.digital_write(Low);
+    }
+  }
+
   pub fn poll_data_ready(&mut self) {
     // poll the data ready pin till low (active low)
     let drdy_pin = self.drdy_mappings.get(&self.measurement).unwrap();

--- a/sam/src/adc.rs
+++ b/sam/src/adc.rs
@@ -449,14 +449,14 @@ pub fn gpio_controller_mappings( // --> whats on the board
     v_valve_pin.mode(Output);
 
   HashMap::from([
-    //(Measurement::CurrentLoopPt, cl_pin),
+    //(Measurement::CurrentLoopPt, cl_pin), // dedicated CS pin ?
     (Measurement::IValve, i_valve_pin),
     (Measurement::VValve, v_valve_pin),
     //(Measurement::VPower, v_power_pin),
     //(Measurement::IPower, i_power_pin),
     //(Measurement::Tc1, tc_1_pin),
     //(Measurement::Tc2, tc_2_pin),
-    //(Measurement::DiffSensors, diff_pin),
+    //(Measurement::DiffSensors, diff_pin), // dedicated CS pin ?
     (Measurement::Rtd, rtd1_pin),
     (Measurement::Rtd, rtd2_pin),
     (Measurement::Rtd, rtd3_pin),

--- a/sam/src/adc.rs
+++ b/sam/src/adc.rs
@@ -74,26 +74,29 @@ impl ADC {
     cs_gpios
   }
 
-  pub fn init_gpio(&mut self, prev_adc: Option<Measurement>) {
-    // pull old adc HIGH
-    if let Some(old_adc) = prev_adc {
-      if let Some(pin) = self.gpio_mappings.get(&old_adc) {
-        pin.digital_write(High);
-      }
-    }
+  // DO NOT USE THIS FUNCTION
+  // pub fn init_gpio(&mut self, prev_adc: Option<Measurement>) {
+  //   // pull old adc HIGH
+  //   if let Some(old_adc) = prev_adc {
+  //     if let Some(pin) = self.gpio_mappings.get(&old_adc) {
+  //       pin.digital_write(High);
+  //     }
+  //   }
 
-    // pull new adc LOW
-    if let Some(pin) = self.gpio_mappings.get(&self.measurement) {
-      pin.digital_write(Low);
-    }
-  }
+  //   // pull new adc LOW
+  //   if let Some(pin) = self.gpio_mappings.get(&self.measurement) {
+  //     pin.digital_write(Low);
+  //   }
+  // }
 
+  // selects current ADC
   pub fn pull_cs_high_active_low(&mut self) {
     if let Some(pin) = self.gpio_mappings.get(&self.measurement) {
       pin.digital_write(High);
     }
   }
 
+  // deselects current ADC
   pub fn pull_cs_low_active_low(&mut self) {
     if let Some(pin) = self.gpio_mappings.get(&self.measurement) {
       pin.digital_write(Low);

--- a/sam/src/adc.rs
+++ b/sam/src/adc.rs
@@ -26,7 +26,14 @@ pub enum Measurement {
   Tc2,
   DiffSensors,
   Rtd,
+  Power,
 }
+
+pub enum ADCEnum {
+  ADC(ADC),
+  OnboardADC,
+}
+
 
 pub struct ADC {
   pub measurement: Measurement,
@@ -129,6 +136,8 @@ impl ADC {
         self.write_reg(0x04, 0x1E);
         self.write_reg(0x05, 0x0A);
       }
+
+      Measurement::Power => ()
     }
 
     // delay for at least 4000*clock period
@@ -320,6 +329,8 @@ impl ADC {
         }
         _ => fail!("Failed register write — could not mod iteration"),
       },
+
+      Measurement::Power => ()
     }
   }
 

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -156,7 +156,7 @@ impl State {
         data.adcs = Some(vec![
           ds,
           cl,
-          vvalve,
+          // vvalve,
           ivalve,
           pwr
         ]);
@@ -540,7 +540,7 @@ fn create_spi(bus: &str) -> io::Result<Spidev> {
 // pinout is for flight version
 pub fn read_onboard_adc(channel: u64) -> (f64, adc::Measurement) {
   let data = match fs::read_to_string(RAIL_PATHS[channel as usize]) {
-    Ok(data) => data,
+    Ok(output) => output,
     Err(_e) => {
       eprintln!("Fail to read {}", RAIL_PATHS[channel as usize]);
       if channel == 0 || channel == 1 || channel == 3 {

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -542,7 +542,7 @@ pub fn read_onboard_adc(channel: u64) -> (f64, adc::Measurement) {
   let data = match fs::read_to_string(RAIL_PATHS[channel as usize]) {
     Ok(data) => data,
     Err(_e) => {
-      println!("Fail to read {}", RAIL_PATHS[channel as usize]);
+      eprintln!("Fail to read {}", RAIL_PATHS[channel as usize]);
       if channel == 0 || channel == 1 || channel == 3 {
         return (-1.0, adc::Measurement::VPower)
       } else {
@@ -552,7 +552,7 @@ pub fn read_onboard_adc(channel: u64) -> (f64, adc::Measurement) {
   };
 
   if data.is_empty() {
-    println!("Empty data for on board ADC channel {}", channel);
+    eprintln!("Empty data for on board ADC channel {}", channel);
     if channel == 0 || channel == 1 || channel == 3 {
       return (-1.0, adc::Measurement::VPower)
     } else {
@@ -571,7 +571,7 @@ pub fn read_onboard_adc(channel: u64) -> (f64, adc::Measurement) {
     },
 
     Err(_e) => {
-      println!("Fail to convert from String to f64 for onboard ADC channel {}", channel);
+      eprintln!("Fail to convert from String to f64 for onboard ADC channel {}", channel);
       if channel == 0 || channel == 1 || channel == 3 {
         (-1.0, adc::Measurement::VPower)
       } else {

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -411,7 +411,7 @@ impl State {
               ADCEnum::ADC(adc) => {
                 let diff_reached_max_channel = i > 2 && adc.measurement == adc::Measurement::DiffSensors;
                 let rtd_reached_max_channel = i > 1 && adc.measurement == adc::Measurement::Rtd;
-                if (diff_reached_max_channel || rtd_reached_max_channel) {
+                if diff_reached_max_channel || rtd_reached_max_channel {
                   continue;
                 }
 
@@ -538,44 +538,44 @@ fn create_spi(bus: &str) -> io::Result<Spidev> {
 }
 
 // pinout is for flight version
-pub fn read_onboard_adc(channel: u8) -> (f64, adc::Measurement) {
-  let data = match fs::read_to_string(RAIL_PATHS[channel]) {
+pub fn read_onboard_adc(channel: u64) -> (f64, adc::Measurement) {
+  let data = match fs::read_to_string(RAIL_PATHS[channel as usize]) {
     Ok(data) => data,
-    Err(e) => {
-      println!("Fail to read {}", RAIL_PATHS[channel]);
-      if (channel == 0 || channel == 1 || channel == 3) {
-        return (-1, adc::Measurement::VPower)
+    Err(_e) => {
+      println!("Fail to read {}", RAIL_PATHS[channel as usize]);
+      if channel == 0 || channel == 1 || channel == 3 {
+        return (-1.0, adc::Measurement::VPower)
       } else {
-        return (-1, adc::Measurement::IPower)
+        return (-1.0, adc::Measurement::IPower)
       }
     }
   };
 
   if data.is_empty() {
-    println!("Empty data for on board ADC channel {}", onboard_analog_channel);
-    if (channel == 0 || channel == 1 || channel == 3) {
-      return (-1, adc::Measurement::VPower)
+    println!("Empty data for on board ADC channel {}", channel);
+    if channel == 0 || channel == 1 || channel == 3 {
+      return (-1.0, adc::Measurement::VPower)
     } else {
-      return (-1, adc::Measurement::IPower)
+      return (-1.0, adc::Measurement::IPower)
     }
   }
 
   match data.trim().parse::<f64>() {
     Ok(data) => {
       let voltage = 1.8 * (data as f64) / ((1 << 12) as f64);
-      if (channel == 0 || channel == 1 || channel == 3) {
+      if channel == 0 || channel == 1 || channel == 3 {
         ((voltage * (4700.0 + 100000.0) / 4700.0), adc::Measurement::VPower)
       } else {
         (voltage, adc::Measurement::IPower)
       }
     },
 
-    Err(e) => {
+    Err(_e) => {
       println!("Fail to convert from String to f64 for onboard ADC channel {}", channel);
-      if (channel == 0 || channel == 1 || channel == 3) {
-        (-1, adc::Measurement::VPower)
+      if channel == 0 || channel == 1 || channel == 3 {
+        (-1.0, adc::Measurement::VPower)
       } else {
-        (-1, adc::Measurement::IPower)
+        (-1.0, adc::Measurement::IPower)
       }
     }
   }

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -249,38 +249,6 @@ impl State {
         State::Identity
       }
 
-      // State::InitAdcs => {
-      //   let mut prev_offboard_measurement: Option<adc::Measurement> = None;
-      //   for adc_enum in data.adcs.as_mut().unwrap() {
-      //     match adc_enum {
-      //       ADCEnum::ADC(adc) => {
-      //         /*
-      //         data.curr_measurement is the "old" measurement before it gets
-      //         immediately updated by the current ADC measurement
-      //          */
-      //         //adc.init_gpio(data.curr_measurement); // replace with prev_measurement
-      //         adc.init_gpio(prev_offboard_measurement);
-      //         data.curr_measurement = Some(adc.measurement); // is this needed
-      //         adc.reset_status();
-    
-      //         adc.init_regs();
-      //         adc.start_conversion();
-    
-      //         adc.write_iteration(0);
-      //         // update prev_measurement here
-      //         prev_offboard_measurement = Some(adc.measurement)
-      //       },
-
-      //       ADCEnum::OnboardADC => {
-      //         // don't have to do anything to initialize
-      //       }
-      //     }
-      //   }
-
-      //   pass!("Initialized ADCs");
-      //   State::PollAdcs
-      // }
-
       State::InitAdcs => {
         for adc_enum in data.adcs.as_mut().unwrap() {
           match adc_enum {
@@ -303,105 +271,6 @@ impl State {
         pass!("Initialized ADCs");
         State::Identity
       }
-
-      // State::PollAdcs => {
-      //   data.data_points.clear();
-      //   let mut prev_offboard_measurement: Option<ADC::Measurement> = None;
-
-      //   for i in 0..6 {
-      //     for adc_enum in data.adcs.as_mut().unwrap() {
-
-      //     let (raw_value, unix_timestamp) = match adc_enum {
-      //       ADCEnum::OnboardADC => {
-      //         let power_reached_max_channel = i > 4 && adc.measurement == adc::Measurement::Power;
-      //         if (power) {
-      //           continue;
-      //         }
-              
-
-      //       }
-
-      //       ADCEnum::ADC(adc) => {
-      //         let diff_reached_max_channel = i > 2 && adc.measurement == adc::Measurement::DiffSensors;
-      //         let rtd_reached_max_channel = i > 1 && adc.measurement == adc::Measurement::Rtd;
-      //         if (diff_reached_max_channel || rtd_reached_max_channel) {
-      //           continue;
-      //         }
-
-      //         adc.init_gpio(prev_measurement);
-      //         data.curr_measurement = Some(adc.measurement);
-      //         let (val, time) = adc.get_adc_reading(i);
-      //         adc.write_iteration(i + 1);
-      //         (val, time)
-      //       }
-      //     };
-
-      //       // variable suffix of reached_max_channel denotes nothing left to read
-      //       let diff_reached_max_channel = i > 2 && adc.measurement == adc::Measurement::DiffSensors;
-      //       let power_reached_max_channel = i > 4 && adc.measurement == adc::Measurement::Power;
-      //       let rtd_reached_max_channel = i > 1 && adc.measurement == adc::Measurement::Rtd;
-
-      //       if (diff_reached_max_channel || power_reached_max_channel || rtd_reached_max_channel) { continue; }
-
-      //       // if (i > 2 && adc.measurement == adc::Measurement::DiffSensors)
-      //       //   || (i > 4 && adc.measurement == adc::Measurement::VPower)
-      //       //   || (i > 1
-      //       //     && (adc.measurement == adc::Measurement::IPower
-      //       //       || adc.measurement == adc::Measurement::Rtd))
-      //       //   || (i > 3
-      //       //     && (adc.measurement == adc::Measurement::Tc1
-      //       //       || adc.measurement == adc::Measurement::Tc2))
-      //       // {
-      //       //   continue;
-      //       // }
-
-      //       /*
-      //       data.curr_measurement is the measurement type of the previous ADC
-      //       before it gets updated in the next line. That value maps to a CS pin
-      //       for the previous ADC and then pulls that CS pin high (active low)
-      //       Then the measurement type of data gets updated by the current ADC
-      //        */
-      //       adc.init_gpio(data.curr_measurement); // change function name
-      //       data.curr_measurement = Some(adc.measurement);
-
-      //       // Read ADC
-      //       let (raw_value, unix_timestamp) = adc.get_adc_reading(i);
-
-      //       // Write ADC for next iteration
-      //       adc.write_iteration(i + 1);
-
-      //       // Don't add ambient temp reading to FC message
-      //       // With removal of TCs this code will never be executed
-      //       if i == 0
-      //         && (adc.measurement == adc::Measurement::Tc1
-      //           || adc.measurement == adc::Measurement::Tc2)
-      //       {
-      //         continue;
-      //       }
-
-      //       let data_point = generate_data_point(
-      //         raw_value,
-      //         unix_timestamp,
-      //         i,
-      //         adc.measurement,
-      //       );
-
-      //       data.data_points.push(data_point)
-      //     }
-      //   }
-
-      //   if let Some(board_id) = data.board_id.clone() {
-      //     let serialized = serialize_data(board_id, &data.data_points);
-
-      //     if let Some(socket_addr) = data.flight_computer {
-      //       data
-      //         .data_socket
-      //         .send_to(&serialized.unwrap(), socket_addr)
-      //         .expect("couldn't send data to flight computer");
-      //     }
-      //   }
-      //   State::PollAdcs
-      // }
 
       State::PollAdcs => {
         data.data_points.clear();
@@ -433,14 +302,6 @@ impl State {
                 (val, 0.0, rail_measurement)
               }
             };
-
-            // if measurement == adc::Measurement::VPower {
-            //   println!("AIN {}: {} V", i, raw_value);
-            // }
-
-            // if measurement == adc::Measurement::IPower {
-            //   println!("AIN {}: {} A", i, raw_value);
-            // }
 
             let data_point = generate_data_point(raw_value, unix_timestamp, i, measurement);
             data.data_points.push(data_point);

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -415,18 +415,27 @@ impl State {
                   continue;
                 }
 
-
+                adc.pull_cs_low_active_low(); // select current ADC
+                data.curr_measurement = Some(adc.measurement); // set measurement of current data struct
+                let (val, time) = adc.get_adc_reading(i); // get data and time
+                adc.write_iteration(i + 1); // perform pin mux to next channel or reading
+                adc.pull_cs_high_active_low(); // deselect current ADC
+                (val, time)
               },
 
               ADCEnum::OnboardADC => {
                 if i > 4 {
                   continue;
                 }
-                
+
+                let (val, measurement) = read_onboard_adc(i);
+                data.curr_measurement = Some(measurement);
+                (val, 0.0)
               }
-            }
+            };
           }
         }
+      }
       }
     }
   }

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -167,7 +167,7 @@ impl State {
           .expect("set_nonblocking call failed");
         data.board_id = get_board_id();
 
-        State::InitAdcs
+        State::DeviceDiscovery
       }
 
       State::DeviceDiscovery => {
@@ -301,7 +301,7 @@ impl State {
         }
 
         pass!("Initialized ADCs");
-        State::PollAdcs
+        State::Identity
       }
 
       // State::PollAdcs => {
@@ -433,6 +433,14 @@ impl State {
                 (val, 0.0, rail_measurement)
               }
             };
+
+            // if measurement == adc::Measurement::VPower {
+            //   println!("AIN {}: {} V", i, raw_value);
+            // }
+
+            // if measurement == adc::Measurement::IPower {
+            //   println!("AIN {}: {} A", i, raw_value);
+            // }
 
             let data_point = generate_data_point(raw_value, unix_timestamp, i, measurement);
             data.data_points.push(data_point);


### PR DESCRIPTION
I added functionality for reading data from the onboard adc of the beaglebone. I made an ADCEnum to hold either a traditional offboard ADC or an onboard ADC so any loop that iterates through a vector of ADCS now matches on the type of ADCEnum and then proceeds. The previous chip select code stored the previous measurement in the data struct, accessed that value and used that value to map to a corresponding chip select pin of an ADC of that measurement type. That ADC was then deselected and the current ADC was selected. With an onboard ADC thrown into the loop that does not use SPI, we would have had to keep track of a measurement from 2 previous iterations. Now for each iteration of PollADC we select the current ADC, do whatever we need to do, then deselect it. We do not rely upon any previous data. The function to read onboard adc data was created and reads from files in the linux file tree. Checks are made to see if the file cannot be read, if the data is empty, or if the data cannot be converted to f64. In those cases an eprintln! is executed and the data returned is -1.