### PR TITLE
Update ahrs 3.3v field for servo data export

### DIFF
--- a/servo/src/server/routes/data.rs
+++ b/servo/src/server/routes/data.rs
@@ -258,7 +258,7 @@ pub async fn export(
       header += ",accelerometer_x,accelerometer_y,accelerometer_z,gyroscope_x,gyroscope_y, gyroscope_z,";
       header += "magnetometer_x,magnetometer_y,magnetometer_z,";
       header += "barometer_temp,barometer_pressure,";
-      header += "ahrs_5v,ahrs_3.3v,";
+      header += "ahrs_5v,ahrs_3_3_v,";
 
       let mut content = header + "\n";
 


### PR DESCRIPTION
Per Dakota's request, a matlab script had an issue with parsing ahrs_3.3_v due to the period in between the 3s. Only affects servo data exports. 