### PR TITLE
[AVI-280] Fix sam-3* Radio Omission Bug

### DIFF
--- a/common/src/comm.rs
+++ b/common/src/comm.rs
@@ -464,11 +464,12 @@ pub struct NodeMapping {
 
 /// Returns whether a node mapping should be included in TEL radio telemetry.
 ///
-/// Only SAM boards whose hostnames begin with `sam-2` are mounted on the
-/// vehicle. Other SAMs remain part of the full umbilical state but are omitted
-/// from the radio subset.
+/// Only SAM boards whose hostnames begin with `sam-2` or `sam-3 are mounted on
+/// the vehicle. Other SAMs remain part of the full umbilical state but are
+/// omitted from the radio subset.
 pub fn include_in_radio_telemetry(mapping: &NodeMapping) -> bool {
   mapping.board_id.starts_with("sam-2")
+  || mapping.board_id.starts_with("sam-3")
 }
 
 /// A sequence written in Python, used by the flight computer to execute

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,15 @@
+I'm developing a Renode simulation for the RECO board in this rocket avionics repository. So far, the
+  C# peripherals for the magnetometer, barometer, and IMU have been completed and are in the sitl/
+  peripherals directory. However, integration with the RECO source code at reco/ as well as simulation
+  of flight interacting with RECO is not complete. Note that I do not want the actual flight software
+  included in this simulation yet, I just want a barebones simulation of flight's interation with RECO.
+  I also want real-time data streaming capabilities, using data collected from previous actual tests for
+  pressure, magnetic fields, GPS, acceleration, rotation, etc. These will be provided in the RESD
+  format, as Renode expects.
+
+  To understand the hardware specification that RECO is running on, read docs/hardware/reco/rev5.md .
+  Next, create a plan to use Renode to simulate RECO, taking in sensor data from RESD files with time-
+  series data, passing it through the simulated peripheral sensors, and having the actual STM32
+  microcontrollers being emulated with the real RECO source code running on them. Put this plan in
+  WORKING.md , and as you work, check off implementation details. Clear the plan with me before
+  starting.

--- a/servo/src/server/telemetry.rs
+++ b/servo/src/server/telemetry.rs
@@ -239,14 +239,18 @@ mod tests {
       mapping("VLV01", "sam-21", SensorType::Valve),
       mapping("VLV01_I", "sam-21", SensorType::RailCurrent),
       mapping("VLV01_V", "sam-21", SensorType::RailVoltage),
+      mapping("VLV02", "sam-31", SensorType::Valve),
+      mapping("VLV02_I", "sam-31", SensorType::RailCurrent),
+      mapping("VLV02_V", "sam-31", SensorType::RailVoltage),
       mapping("PT01", "sam-21", SensorType::Pt),
+      mapping("PT02", "sam-31", SensorType::Pt),
       mapping("GROUND_PT", "sam-01", SensorType::Pt),
       mapping("GROUND_VALVE", "sam-01", SensorType::Valve),
       mapping("GROUND_VALVE_I", "sam-01", SensorType::RailCurrent),
     ]);
 
-    assert_eq!(schema.valve_keys(), ["VLV01"]);
-    assert_eq!(schema.sensor_keys(), ["PT01"]);
-    assert_eq!(schema.sensor_units(), [Unit::Psi]);
+    assert_eq!(schema.valve_keys(), ["VLV01", "VLV02"]);
+    assert_eq!(schema.sensor_keys(), ["PT01", "PT02"]);
+    assert_eq!(schema.sensor_units(), [Unit::Psi, Unit::Psi]);
   }
 }

--- a/sitl/isolab/src/client.rs
+++ b/sitl/isolab/src/client.rs
@@ -230,7 +230,10 @@ pub fn count_valve_helper_sensors(mappings: &[NodeMapping]) -> usize {
 pub fn count_non_radio_mappings(mappings: &[NodeMapping]) -> usize {
   mappings
     .iter()
-    .filter(|mapping| !mapping.board_id.starts_with("sam-2"))
+    .filter(|mapping| {
+      !mapping.board_id.starts_with("sam-2")
+      && !mapping.board_id.starts_with("sam-3")
+    })
     .count()
 }
 


### PR DESCRIPTION
The Telemetry Support PR had a bug where is didn't include SAM boards of the form `sam-3*` as flight boards. This PR fixes that. Unit tests were updated to provide coverage of this change.