### PR TITLE
Fix duration overflow issue with file loggers

### DIFF
--- a/flight2/src/file_logger.rs
+++ b/flight2/src/file_logger.rs
@@ -173,14 +173,15 @@ impl FileLogger {
 
     loop {
       // Check for batch timeout
-      let should_flush_timeout = last_flush.elapsed() >= config.batch_timeout;
+      let elapsed = last_flush.elapsed();
+      let should_flush_timeout = elapsed >= config.batch_timeout;
       let should_flush_batch = batch.len() >= config.batch_size;
 
       // Try to receive with timeout
       let timeout = if should_flush_timeout || should_flush_batch {
         Duration::ZERO
       } else {
-        config.batch_timeout - last_flush.elapsed()
+        config.batch_timeout - elapsed
       };
 
       match receiver.recv_timeout(timeout) {

--- a/flight2/src/imu_logger.rs
+++ b/flight2/src/imu_logger.rs
@@ -192,13 +192,14 @@ impl FileLogger {
     let mut file_size: usize = 0;
 
     loop {
-      let should_flush_timeout = last_flush.elapsed() >= config.batch_timeout;
+      let elapsed = last_flush.elapsed();
+      let should_flush_timeout = elapsed >= config.batch_timeout;
       let should_flush_batch = batch.len() >= config.batch_size;
 
       let timeout = if should_flush_timeout || should_flush_batch {
         Duration::ZERO
       } else {
-        config.batch_timeout - last_flush.elapsed()
+        config.batch_timeout - elapsed
       };
 
       match receiver.recv_timeout(timeout) {


### PR DESCRIPTION
Observed an issue during launch-prep day where the IMU file logger thread panicked due to an `overflow when subtracting durations` error, which in turn caused the IMU / ADC thread to panic. This error is the result of calling the `elapsed()` on the same variable twice in succession, where the second instance of the `elapsed()` is involved in a subtraction operation.  This can cause an overflow to occur as subtractions between `Duration` types operate under the assumption that the right-hand-side of the expression is less than the left-hand-side of the expression (`x - y >= 0`), and if this is violated the program panics. 

A fix was implemented such that the `elapsed()` is called once and saved in a variable, and that variable is used twice. This issue persisted in both the `IMU` and `VehicleState` file loggers, and the fix was implemented for both file loggers. 

A detailed example of a scenario where the issue would pop up is detailed here https://github.com/gt-space/luna/pull/139#discussion_r3061590463