### PR TITLE
Dev/avi 274/darcy pt

### DIFF
--- a/common/src/comm.rs
+++ b/common/src/comm.rs
@@ -533,9 +533,11 @@ pub struct NodeMapping {
 ///
 /// Only SAM boards whose hostnames begin with `sam-2` or `sam-3 are mounted on
 /// the vehicle. Other SAMs remain part of the full umbilical state but are
-/// omitted from the radio subset.
+/// omitted from the radio subset. Additionally, if the flight computer PT channel
+/// is mapped it should be included in the radio subset.
 pub fn include_in_radio_telemetry(mapping: &NodeMapping) -> bool {
-  mapping.board_id.starts_with("sam-2")
+  mapping.board_id == "flight"
+  || mapping.board_id.starts_with("sam-2")
   || mapping.board_id.starts_with("sam-3")
 }
 

--- a/common/src/comm/fc_sensors.rs
+++ b/common/src/comm/fc_sensors.rs
@@ -86,6 +86,31 @@ pub struct Barometer {
   pub pressure: Pascals,
 }
 
+/// Represents ADC data sampled on the flight computer.
+#[compress(CompressedAdcData)]
+#[derive(
+  Deserialize,
+  Serialize,
+  Clone,
+  Copy,
+  MaxSize,
+  Debug,
+  PartialEq,
+  Default,
+  rkyv::Archive,
+  rkyv::Serialize,
+  rkyv::Deserialize,
+)]
+#[archive_attr(derive(bytecheck::CheckBytes))]
+pub struct AdcData {
+  /// 3V3 rail
+  pub rail_3v3: Rail,
+  /// 5V rail
+  pub rail_5v: Rail,
+  /// Current-loop PT reading before mapping conversion.
+  pub current_loop_pt: f64,
+}
+
 /// Represents the state of the flight computer's onboard sensors.
 #[compress(CompressedFcSensors)]
 #[derive(
@@ -103,14 +128,10 @@ pub struct Barometer {
 )]
 #[archive_attr(derive(bytecheck::CheckBytes))]
 pub struct FcSensors {
-  /// 3V3 rail
-  pub rail_3v3: Rail,
-  /// 5V rail
-  pub rail_5v: Rail,
-  /// Current-loop PT reading before mapping conversion.
-  pub current_loop_pt: f64,
   /// IMU data
   pub imu: Imu,
+  /// ADC data
+  pub adc: AdcData,
   /// Magnetometer data
   pub magnetometer: Magnetometer,
   /// Barometer data

--- a/common/src/comm/fc_sensors.rs
+++ b/common/src/comm/fc_sensors.rs
@@ -107,6 +107,8 @@ pub struct FcSensors {
   pub rail_3v3: Rail,
   /// 5V rail
   pub rail_5v: Rail,
+  /// Current-loop PT reading before mapping conversion.
+  pub current_loop_pt: f64,
   /// IMU data
   pub imu: Imu,
   /// Magnetometer data

--- a/common/src/comm/vehicle.rs
+++ b/common/src/comm/vehicle.rs
@@ -673,10 +673,10 @@ mod tests {
     state.bms.e_stop = rng.next_f64(0.0, 15.0);
     state.bms.rbf_tag = rng.next_f64(0.0, 15.0);
 
-    state.fc_sensors.rail_3v3.voltage = rng.next_f64(3.0, 3.6);
-    state.fc_sensors.rail_3v3.current = rng.next_f64(0.0, 5.0);
-    state.fc_sensors.rail_5v.voltage = rng.next_f64(4.5, 5.5);
-    state.fc_sensors.rail_5v.current = rng.next_f64(0.0, 5.0);
+    state.fc_sensors.adc.rail_3v3.voltage = rng.next_f64(3.0, 3.6);
+    state.fc_sensors.adc.rail_3v3.current = rng.next_f64(0.0, 5.0);
+    state.fc_sensors.adc.rail_5v.voltage = rng.next_f64(4.5, 5.5);
+    state.fc_sensors.adc.rail_5v.current = rng.next_f64(0.0, 5.0);
     state.fc_sensors.imu.accelerometer = random_vector(&mut rng);
     state.fc_sensors.imu.gyroscope = random_vector(&mut rng);
     state.fc_sensors.magnetometer = random_vector(&mut rng);
@@ -815,10 +815,10 @@ mod tests {
     state.bms.chassis = 12.4;
     state.bms.e_stop = 11.9;
     state.bms.rbf_tag = 0.4;
-    state.fc_sensors.rail_3v3.voltage = 3.31;
-    state.fc_sensors.rail_3v3.current = 0.8;
-    state.fc_sensors.rail_5v.voltage = 5.02;
-    state.fc_sensors.rail_5v.current = 1.1;
+    state.fc_sensors.adc.rail_3v3.voltage = 3.31;
+    state.fc_sensors.adc.rail_3v3.current = 0.8;
+    state.fc_sensors.adc.rail_5v.voltage = 5.02;
+    state.fc_sensors.adc.rail_5v.current = 1.1;
     state.fc_sensors.imu.accelerometer = fc_sensors::Vector {
       x: 1.1,
       y: -2.2,
@@ -946,14 +946,14 @@ mod tests {
     expected.bms.chassis = half_roundtrip_f64(state.bms.chassis);
     expected.bms.e_stop = half_roundtrip_f64(state.bms.e_stop);
     expected.bms.rbf_tag = half_roundtrip_f64(state.bms.rbf_tag);
-    expected.fc_sensors.rail_3v3.voltage =
-      half_roundtrip_f64(state.fc_sensors.rail_3v3.voltage);
-    expected.fc_sensors.rail_3v3.current =
-      half_roundtrip_f64(state.fc_sensors.rail_3v3.current);
-    expected.fc_sensors.rail_5v.voltage =
-      half_roundtrip_f64(state.fc_sensors.rail_5v.voltage);
-    expected.fc_sensors.rail_5v.current =
-      half_roundtrip_f64(state.fc_sensors.rail_5v.current);
+    expected.fc_sensors.adc.rail_3v3.voltage =
+      half_roundtrip_f64(state.fc_sensors.adc.rail_3v3.voltage);
+    expected.fc_sensors.adc.rail_3v3.current =
+      half_roundtrip_f64(state.fc_sensors.adc.rail_3v3.current);
+    expected.fc_sensors.adc.rail_5v.voltage =
+      half_roundtrip_f64(state.fc_sensors.adc.rail_5v.voltage);
+    expected.fc_sensors.adc.rail_5v.current =
+      half_roundtrip_f64(state.fc_sensors.adc.rail_5v.current);
     expected.fc_sensors.imu.accelerometer = fc_sensors::Vector {
       x: half_roundtrip_f64(state.fc_sensors.imu.accelerometer.x),
       y: half_roundtrip_f64(state.fc_sensors.imu.accelerometer.y),

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -32,6 +32,7 @@ use crate::{
   gps::{GpsHandle, RecoControlMessage},
   sensors::{BarometerData, ImuAdcSample},
   sequence::Sequences,
+  state::process_flight_pt_data,
   Ingestible,
   DECAY,
   DEVICE_COMMAND_PORT,
@@ -166,12 +167,18 @@ impl Devices {
     }
   }
 
-  /// Update flight-computer-local IMU and rail measurements into the
+  /// Update flight-computer-local IMU and ADC data into the
   /// VehicleState
-  pub(crate) fn update_fc_imu_adc(&mut self, sample: &ImuAdcSample) {
+  pub(crate) fn update_fc_imu_adc(
+    &mut self,
+    sample: &ImuAdcSample,
+    mappings: &Mappings,
+  ) {
     self.state.fc_sensors.imu = sample.imu;
     self.state.fc_sensors.rail_3v3 = sample.rail_3v3;
     self.state.fc_sensors.rail_5v = sample.rail_5v;
+    self.state.fc_sensors.current_loop_pt = sample.current_loop_pt;
+    process_flight_pt_data(&mut self.state, sample.current_loop_pt, mappings);
   }
 
   pub(crate) fn update_fc_mag_bar(

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -175,10 +175,12 @@ impl Devices {
     mappings: &Mappings,
   ) {
     self.state.fc_sensors.imu = sample.imu;
-    self.state.fc_sensors.rail_3v3 = sample.rail_3v3;
-    self.state.fc_sensors.rail_5v = sample.rail_5v;
-    self.state.fc_sensors.current_loop_pt = sample.current_loop_pt;
-    process_flight_pt_data(&mut self.state, sample.current_loop_pt, mappings);
+    self.state.fc_sensors.adc = sample.adc;
+    process_flight_pt_data(
+      &mut self.state,
+      sample.adc.current_loop_pt,
+      mappings,
+    );
   }
 
   pub(crate) fn update_fc_mag_bar(

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -476,7 +476,7 @@ fn main() -> ! {
     // Ingest any newly available IMU/ADC samples from the worker
     if let Some(handle) = imu_adc_handle.as_ref() {
       while let Ok(sample) = handle.try_read() {
-        devices.update_fc_imu_adc(&sample);
+        devices.update_fc_imu_adc(&sample, &mappings);
       }
     }
 

--- a/flight2/src/sensors.rs
+++ b/flight2/src/sensors.rs
@@ -6,7 +6,7 @@ use crate::imu_logger::{
 use ads124s06::ADC;
 use common::comm::{
   bms::Rail,
-  fc_sensors::{Imu, Vector},
+  fc_sensors::{AdcData, Imu, Vector},
   gpio::{GpioPin, PinMode, PinValue, RpiGpioController},
   ADCError,
   ADCFamily,
@@ -183,27 +183,12 @@ pub fn spawn_mag_bar_worker(
   }))
 }
 
-/// ADC rail measurements from a single sampling pass.
-pub struct AdcData {
-  /// 3V3 rail voltage and current.
-  pub rail_3v3: Rail,
-  /// 5V rail voltage and current.
-  pub rail_5v: Rail,
-  /// Current-loop PT reading. This is just the scaled voltage value,
-  /// and does not account for the PT calibration.
-  pub current_loop_pt: f64,
-}
-
 /// Combined sample from the IMU and all rail channels.
 pub struct ImuAdcSample {
   /// IMU state (accelerometer + gyroscope), using the shared `Imu` type.
   pub imu: Imu,
-  /// 3V3 rail voltage and current.
-  pub rail_3v3: Rail,
-  /// 5V rail voltage and current.
-  pub rail_5v: Rail,
-  /// Current-loop PT reading before mapping conversion.
-  pub current_loop_pt: f64,
+  /// Sampled ADC data.
+  pub adc: AdcData,
 }
 
 /// Errors that can occur while starting the IMU+ADC worker.
@@ -582,9 +567,7 @@ pub fn spawn_imu_adc_worker(
     let adc_data = sample_adc_channels(&mut adc, ADC_DRDY_TIMEOUT);
     let sample = ImuAdcSample {
       imu: current_imu_sample,
-      rail_3v3: adc_data.rail_3v3,
-      rail_5v: adc_data.rail_5v,
-      current_loop_pt: adc_data.current_loop_pt,
+      adc: adc_data,
     };
 
     if tx.send(sample).is_err() {

--- a/flight2/src/sensors.rs
+++ b/flight2/src/sensors.rs
@@ -39,6 +39,7 @@ const CURRENT_3V3_SCALE: f64 = 1.0;
 const VOLTAGE_3V3_SCALE: f64 = 2.0;
 const CURRENT_5V_SCALE: f64 = 5.0 / 3.0;
 const VOLTAGE_5V_SCALE: f64 = 3.0;
+const CURRENT_LOOP_PT_SCALE: f64 = 2.0;
 
 /// Global Raspberry Pi GPIO controller that isopened once and shared safely.
 fn gpio_controller() -> &'static RpiGpioController {
@@ -188,6 +189,9 @@ pub struct AdcData {
   pub rail_3v3: Rail,
   /// 5V rail voltage and current.
   pub rail_5v: Rail,
+  /// Current-loop PT reading. This is just the scaled voltage value,
+  /// and does not account for the PT calibration.
+  pub current_loop_pt: f64,
 }
 
 /// Combined sample from the IMU and all rail channels.
@@ -198,6 +202,8 @@ pub struct ImuAdcSample {
   pub rail_3v3: Rail,
   /// 5V rail voltage and current.
   pub rail_5v: Rail,
+  /// Current-loop PT reading before mapping conversion.
+  pub current_loop_pt: f64,
 }
 
 /// Errors that can occur while starting the IMU+ADC worker.
@@ -387,7 +393,7 @@ fn read_adc_measurement(adc: &mut ADC) -> Option<f64> {
   }
 }
 
-/// ADC input channel assignments for the flight computer rails.
+/// ADC input channel assignments for the flight computer ADC.
 #[derive(Clone, Copy)]
 #[repr(u8)]
 enum AdcChannel {
@@ -395,16 +401,18 @@ enum AdcChannel {
   Rail3v3Voltage,
   Rail5vCurrent,
   Rail5vVoltage,
+  CurrentLoopPt,
 }
 
 // Allows us to iterate over channels in sequential order.
 // Rail3v3Current = 0, Rail3v3Voltage = 1, etc
 impl AdcChannel {
-  const ALL: [Self; 4] = [
+  const ALL: [Self; 5] = [
     Self::Rail3v3Current,
     Self::Rail3v3Voltage,
     Self::Rail5vCurrent,
     Self::Rail5vVoltage,
+    Self::CurrentLoopPt,
   ];
 }
 
@@ -419,6 +427,7 @@ fn sample_adc_channels(adc: &mut ADC, timeout: Duration) -> AdcData {
       voltage: 0.0,
       current: 0.0,
     },
+    current_loop_pt: 0.0,
   };
 
   for ch in AdcChannel::ALL {
@@ -440,6 +449,9 @@ fn sample_adc_channels(adc: &mut ADC, timeout: Duration) -> AdcData {
         }
         AdcChannel::Rail5vVoltage => {
           data.rail_5v.voltage = value * VOLTAGE_5V_SCALE
+        }
+        AdcChannel::CurrentLoopPt => {
+          data.current_loop_pt = value * CURRENT_LOOP_PT_SCALE
         }
       }
 
@@ -572,6 +584,7 @@ pub fn spawn_imu_adc_worker(
       imu: current_imu_sample,
       rail_3v3: adc_data.rail_3v3,
       rail_5v: adc_data.rail_5v,
+      current_loop_pt: adc_data.current_loop_pt,
     };
 
     if tx.send(sample).is_err() {

--- a/flight2/src/state.rs
+++ b/flight2/src/state.rs
@@ -3,6 +3,7 @@ use common::comm::{
   flight::DataMessage, 
   sam::{ChannelType, SamDataPoint, Unit}, CompositeValveState, 
   Measurement, 
+  NodeMapping,
   SensorType, 
   ValveState, 
   VehicleState
@@ -11,6 +12,10 @@ use crate::{Mappings, MMAP_GRACE_PERIOD};
 use mmap_sync::locks::LockDisabled;
 use mmap_sync::synchronizer::{Synchronizer, SynchronizerError};
 use wyhash::WyHash;
+
+// flight-computer PT constants
+const FLIGHT_PT_BOARD_ID: &str = "flight";
+const FLIGHT_PT_MAPPING_CHANNEL: u32 = 5;
 
 pub(crate) fn sync_sequences(
   sync: &mut Synchronizer<WyHash, LockDisabled, 1024, 500_000>,
@@ -73,133 +78,167 @@ pub(crate) fn process_sam_data(board_id: &str, state: &mut VehicleState, datapoi
           if !corresponds {
             continue;
           }
-
-          let mut text_id = mapping.text_id.clone();
-
-          let measurement = match mapping.sensor_type {
-            SensorType::RailVoltage => Measurement {
-              value: data_point.value,
-              unit: Unit::Volts,
-            },
-            SensorType::Rtd | SensorType::Tc => Measurement {
-              value: data_point.value,
-              unit: Unit::Kelvin,
-            },
-            SensorType::RailCurrent => Measurement {
-              value: data_point.value,
-              unit: Unit::Amps,
-            },
-            SensorType::Pt => {
-              let value;
-              let unit;
-
-              // apply linear transformations to current loop and differential
-              // signal channels if the max and min are supplied by the mappings.
-              // otherwise, default back to volts.
-              if let (Some(max), Some(min)) = (mapping.max, mapping.min) {
-                // formula for converting voltage into psi for our PTs
-                // TODO: consider precalculating scale and offset on control server
-                value = (data_point.value - 0.8) / 3.2 * (max - min) + min
-                  - mapping.calibrated_offset;
-                unit = Unit::Psi;
-              } else {
-                // if no PT ratings are set, default to displaying raw voltage
-                value = data_point.value;
-                unit = Unit::Volts;
-              }
-
-              Measurement { value, unit }
-            }
-            SensorType::LoadCell => {
-              // if no load cell mappings are set, default to these values
-              let mut value = data_point.value;
-              let mut unit = Unit::Volts;
-
-              // apply linear transformations to load cell channel if the max and
-              // min are supplied by the mappings. otherwise, default back to volts.
-              if let (Some(max), Some(min)) = (mapping.max, mapping.min) {
-                // formula for converting voltage into pounds for our load cells
-                value = (max - min) / 0.03 * (value + 0.015) + min
-                  - mapping.calibrated_offset;
-                unit = Unit::Pounds;
-              }
-
-              Measurement { value, unit }
-            }
-            SensorType::Valve => {
-              let voltage;
-              let current;
-              let measurement;
-
-              match data_point.channel_type {
-                ChannelType::ValveVoltage => {
-                  voltage = data_point.value;
-                  current = state
-                    .sensor_readings
-                    .get(&format!("{text_id}_I"))
-                    .map(|measurement| measurement.value)
-                    .unwrap_or(0.0);
-
-                  measurement = Measurement {
-                    value: data_point.value,
-                    unit: Unit::Volts,
-                  };
-                  text_id = format!("{text_id}_V");
-                }
-                ChannelType::ValveCurrent => {
-                  current = data_point.value;
-                  voltage = state
-                    .sensor_readings
-                    .get(&format!("{text_id}_V"))
-                    .map(|measurement| measurement.value)
-                    .unwrap_or(0.0);
-
-                  measurement = Measurement {
-                    value: data_point.value,
-                    unit: Unit::Amps,
-                  };
-                  text_id = format!("{text_id}_I");
-                }
-                channel_type => {
-                  eprintln!(
-                    "Measured channel type of '{channel_type:?}' for valve."
-                  );
-                  continue;
-                }
-              };
-
-              let actual_state = estimate_valve_state(
-                voltage,
-                current,
-                mapping.powered_threshold,
-                mapping.normally_closed,
-              );
-
-              if let Some(existing) = state.valve_states.get_mut(&mapping.text_id) {
-                existing.actual = actual_state;
-              } else {
-                state.valve_states.insert(
-                  mapping.text_id.clone(),
-                  CompositeValveState {
-                    commanded: ValveState::Undetermined,
-                    actual: actual_state,
-                  },
-                );
-              }
-
-              measurement
-            }
-          };
-
-          // replace item without cloning string if already present
-          if let Some(existing) = state.sensor_readings.get_mut(&text_id) {
-            *existing = measurement;
-          } else {
-            state.sensor_readings.insert(text_id, measurement);
-          }
+          apply_sensor_mapping(
+            state,
+            mapping,
+            data_point.channel_type,
+            data_point.value,
+          );
         }
       }
     }
+  }
+}
+
+pub(crate) fn process_flight_pt_data(
+  state: &mut VehicleState,
+  sample_value: f64,
+  mappings: &Mappings,
+) {
+  for mapping in mappings {
+    let corresponds = mapping.channel == FLIGHT_PT_MAPPING_CHANNEL
+      && mapping
+        .sensor_type
+        .channel_types()
+        .contains(&ChannelType::CurrentLoop)
+      && mapping.board_id == FLIGHT_PT_BOARD_ID;
+
+    if !corresponds {
+      continue;
+    }
+
+    apply_sensor_mapping(state, mapping, ChannelType::CurrentLoop, sample_value);
+  }
+}
+
+fn apply_sensor_mapping(
+  state: &mut VehicleState,
+  mapping: &NodeMapping,
+  channel_type: ChannelType,
+  sample_value: f64,
+) {
+  let mut text_id = mapping.text_id.clone();
+
+  let measurement = match mapping.sensor_type {
+    SensorType::RailVoltage => Measurement {
+      value: sample_value,
+      unit: Unit::Volts,
+    },
+    SensorType::Rtd | SensorType::Tc => Measurement {
+      value: sample_value,
+      unit: Unit::Kelvin,
+    },
+    SensorType::RailCurrent => Measurement {
+      value: sample_value,
+      unit: Unit::Amps,
+    },
+    SensorType::Pt => {
+      let value;
+      let unit;
+
+      // apply linear transformations to current loop and differential
+      // signal channels if the max and min are supplied by the mappings.
+      // otherwise, default back to volts.
+      if let (Some(max), Some(min)) = (mapping.max, mapping.min) {
+        // formula for converting voltage into psi for our PTs
+        // TODO: consider precalculating scale and offset on control server
+        value = (sample_value - 0.8) / 3.2 * (max - min) + min
+          - mapping.calibrated_offset;
+        unit = Unit::Psi;
+      } else {
+        // if no PT ratings are set, default to displaying raw voltage
+        value = sample_value;
+        unit = Unit::Volts;
+      }
+
+      Measurement { value, unit }
+    }
+    SensorType::LoadCell => {
+      // if no load cell mappings are set, default to these values
+      let mut value = sample_value;
+      let mut unit = Unit::Volts;
+
+      // apply linear transformations to load cell channel if the max and
+      // min are supplied by the mappings. otherwise, default back to volts.
+      if let (Some(max), Some(min)) = (mapping.max, mapping.min) {
+        // formula for converting voltage into pounds for our load cells
+        value = (max - min) / 0.03 * (value + 0.015) + min
+          - mapping.calibrated_offset;
+        unit = Unit::Pounds;
+      }
+
+      Measurement { value, unit }
+    }
+    SensorType::Valve => {
+      let voltage;
+      let current;
+      let measurement;
+
+      match channel_type {
+        ChannelType::ValveVoltage => {
+          voltage = sample_value;
+          current = state
+            .sensor_readings
+            .get(&format!("{text_id}_I"))
+            .map(|measurement| measurement.value)
+            .unwrap_or(0.0);
+
+          measurement = Measurement {
+            value: sample_value,
+            unit: Unit::Volts,
+          };
+          text_id = format!("{text_id}_V");
+        }
+        ChannelType::ValveCurrent => {
+          current = sample_value;
+          voltage = state
+            .sensor_readings
+            .get(&format!("{text_id}_V"))
+            .map(|measurement| measurement.value)
+            .unwrap_or(0.0);
+
+          measurement = Measurement {
+            value: sample_value,
+            unit: Unit::Amps,
+          };
+          text_id = format!("{text_id}_I");
+        }
+        channel_type => {
+          eprintln!(
+            "Measured channel type of '{channel_type:?}' for valve."
+          );
+          return;
+        }
+      };
+
+      let actual_state = estimate_valve_state(
+        voltage,
+        current,
+        mapping.powered_threshold,
+        mapping.normally_closed,
+      );
+
+      if let Some(existing) = state.valve_states.get_mut(&mapping.text_id) {
+        existing.actual = actual_state;
+      } else {
+        state.valve_states.insert(
+          mapping.text_id.clone(),
+          CompositeValveState {
+            commanded: ValveState::Undetermined,
+            actual: actual_state,
+          },
+        );
+      }
+
+      measurement
+    }
+  };
+
+  // replace item without cloning string if already present
+  if let Some(existing) = state.sensor_readings.get_mut(&text_id) {
+    *existing = measurement;
+  } else {
+    state.sensor_readings.insert(text_id, measurement);
   }
 }
 

--- a/gui/src/avi/fc-sensors/fc-sensors.tsx
+++ b/gui/src/avi/fc-sensors/fc-sensors.tsx
@@ -16,10 +16,12 @@ const [fcSensorsData, setFcSensorsData] = createSignal({
     accelerometer: { x: 0, y: 0, z: 0 },
     gyroscope: { x: 0, y: 0, z: 0 }
   },
+  adc: {
+    rail_3v3: { voltage: 0, current: 0 },
+    rail_5v: { voltage: 0, current: 0 },
+    current_loop_pt: 0,
+  },
   magnetometer: { x: 0, y: 0, z: 0 },
-  rail_3v3: { voltage: 0, current: 0 },
-  rail_5v: { voltage: 0, current: 0 },
-  current_loop_pt: 0,
 } as FcSensors_struct);
 // listens to device updates and updates the values of FC Sensor values accordingly for display
 listen('device_update', (event) => {
@@ -130,19 +132,19 @@ function FcSensors() {
           <div class="fc-sensors-data-row-container">
             <div class="fc-sensors-data-row">
               <div class="fc-sensors-data-variable"> 5V Rail Voltage </div>
-              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).rail_5v.voltage).toFixed(4)} </div>
+              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).adc.rail_5v.voltage).toFixed(4)} </div>
             </div>
             <div class="fc-sensors-data-row">
               <div class="fc-sensors-data-variable"> 5V Rail Current </div>
-              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).rail_5v.current).toFixed(4)} </div>
+              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).adc.rail_5v.current).toFixed(4)} </div>
             </div>
             <div class="fc-sensors-data-row">
               <div class="fc-sensors-data-variable"> 3.3V Rail Voltage </div>
-              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).rail_3v3.voltage).toFixed(4)} </div>
+              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).adc.rail_3v3.voltage).toFixed(4)} </div>
             </div>
             <div class="fc-sensors-data-row">
               <div class="fc-sensors-data-variable"> 3.3V Rail Current </div>
-              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).rail_3v3.current).toFixed(4)} </div>
+              <div class="fc-sensors-data-value"> {((fcSensorsData() as FcSensors_struct).adc.rail_3v3.current).toFixed(4)} </div>
             </div>
           </div>
         </div>

--- a/gui/src/avi/fc-sensors/fc-sensors.tsx
+++ b/gui/src/avi/fc-sensors/fc-sensors.tsx
@@ -19,6 +19,7 @@ const [fcSensorsData, setFcSensorsData] = createSignal({
   magnetometer: { x: 0, y: 0, z: 0 },
   rail_3v3: { voltage: 0, current: 0 },
   rail_5v: { voltage: 0, current: 0 },
+  current_loop_pt: 0,
 } as FcSensors_struct);
 // listens to device updates and updates the values of FC Sensor values accordingly for display
 listen('device_update', (event) => {

--- a/gui/src/comm.tsx
+++ b/gui/src/comm.tsx
@@ -182,6 +182,7 @@ export interface FCSensors {
   },
   rail_3v3: Bus,
   rail_5v: Bus,
+  current_loop_pt: number,
 }
 
 // interface to represent RECO data for one MCU

--- a/gui/src/comm.tsx
+++ b/gui/src/comm.tsx
@@ -172,17 +172,21 @@ export interface IMU {
   gyroscope: Vector
 }
 
+export interface FCAdcData {
+  rail_3v3: Bus,
+  rail_5v: Bus,
+  current_loop_pt: number,
+}
+
 // interface to represent fc sensors data
 export interface FCSensors {
   imu: IMU,
+  adc: FCAdcData,
   magnetometer: Vector,
   barometer: {
     pressure: number,
     temperature: number,
   },
-  rail_3v3: Bus,
-  rail_5v: Bus,
-  current_loop_pt: number,
 }
 
 // interface to represent RECO data for one MCU

--- a/gui/src/system/SystemPages.tsx
+++ b/gui/src/system/SystemPages.tsx
@@ -359,6 +359,20 @@ function clear_configuration_error() {
   setCurrentConfigurationError('');
 }
 
+function validateFlightPtMappings(entries: Mapping[]): string | null {
+  for (const entry of entries) {
+    const boardId = entry.board_id.trim().toLowerCase();
+    const sensorType = entry.sensor_type.trim().toLowerCase();
+    const channel = Number(entry.channel);
+
+    if (boardId === 'flight' && sensorType === 'pt' && channel !== 5) {
+      return `Mapping "${entry.text_id || "(unnamed)"}" targets flight PT, so its channel must be 5.`;
+    }
+  }
+
+  return null;
+}
+
 // Returns true on success, false on failure
 async function submitConfig(edited: boolean) {
   var newConfigNameInput = (document.getElementById('newconfigname') as HTMLInputElement)!;
@@ -405,6 +419,17 @@ async function submitConfig(edited: boolean) {
       null : JSON.parse(mappingvalvenormcloseds[i].value.toLowerCase())
   }
   console.log(entries);
+
+  const flightPtValidationError = validateFlightPtMappings(entries);
+  if (flightPtValidationError !== null) {
+    setCurrentConfigurationErrorCode('ERROR : INVALID FLIGHT PT MAPPING');
+    setCurrentConfigurationError(flightPtValidationError);
+    setSaveConfigDisplay("Error!");
+    alert(currentConfigurationErrorCode() + "\n" + flightPtValidationError);
+    await new Promise(r => setTimeout(r, 1000));
+    setSaveConfigDisplay("Save");
+    return false;
+  }
 
   const response = await sendConfig(serverIp() as string, {id: configName, mappings: entries} as Config);
   const statusCode = response.status;

--- a/servo/src/server/routes/data.rs
+++ b/servo/src/server/routes/data.rs
@@ -369,8 +369,8 @@ pub async fn export(
           state.fc_sensors.barometer.pressure,
         );
         content += &format!(",{},{}", 
-          state.fc_sensors.rail_5v.voltage,
-          state.fc_sensors.rail_3v3.voltage,
+          state.fc_sensors.adc.rail_5v.voltage,
+          state.fc_sensors.adc.rail_3v3.voltage,
         );
 
         content += "\n";


### PR DESCRIPTION
Added support for a PT reading on ain4 (channel 5) of the adc on the flight computer board. This includes the ability to include a mapping in a config (with checks to ensure it is only on channel 5 and a PT configured channel if the specified device is flight), proper conversion of raw voltage to PT data, and inclusion via TEL. This behavior has been tested with the Darcy AVI cube. 

Note: I also did a little bit of code reorganization with regards to the AdcData struct which is why there are some GUI / servo changes. 