### PR TITLE
Dev/avi 291/abort stage cleanup

### DIFF
--- a/common/src/comm.rs
+++ b/common/src/comm.rs
@@ -596,6 +596,9 @@ pub enum FlightControlMessage {
   /// Instructs the flight computer to run an immediate abort.
   Abort,
 
+  /// Instructs the flight computer to clear the abort status.
+  ClearAbortStatus,
+
   /// Instructs the flight computer to tell SAMs to toggle camera en/dis
   CameraEnable(bool), // true for enable, false for disable
 

--- a/common/src/comm/flight.rs
+++ b/common/src/comm/flight.rs
@@ -79,11 +79,7 @@ pub enum SequenceDomainCommand {
     stage_name: String,
   },
 
-  /// Tells FC to tell sams to abort via the stage's "safe" valve states.
-  /// Different from Abort message, which runs the abort sequence
-  AbortViaStage,
-
-  /// Tells the FC to run the abort sequence.
+  /// Tells the FC to perform an immediate abort.
   Abort,
 
   /// Tells the FC whether to monitor servo disconnects (and react) or ignore them.

--- a/common/src/comm/flight.rs
+++ b/common/src/comm/flight.rs
@@ -82,6 +82,9 @@ pub enum SequenceDomainCommand {
   /// Tells the FC to perform an immediate abort.
   Abort,
 
+  /// Tells the FC to clear the abort status.
+  ClearAbortStatus,
+
   /// Tells the FC whether to monitor servo disconnects (and react) or ignore them.
   ///
   /// When `enabled` is false, the FC should not abort on servo disconnect timeouts,

--- a/common/src/comm/sam.rs
+++ b/common/src/comm/sam.rs
@@ -177,6 +177,9 @@ pub enum SamControlMessage {
   Abort,
   /// Clears messages that we have stored for an abort stage
   ClearStoredAbortStage{},
+  /// Clears the abort status. This is used to tell a SAM that we are 
+  /// no longer in an abort state, which allows for future aborts to be performed.
+  ClearAbortStatus,
   /// Toggles the camera enable/disable pin
   CameraEnable(bool), // true for enable, false for disable
   /// Toggles the launch lug enable/disable pin

--- a/common/src/comm/sam.rs
+++ b/common/src/comm/sam.rs
@@ -174,10 +174,7 @@ pub enum SamControlMessage {
     valve_states: Vec<ValveAction>,
   },
   /// Tells a board to abort.
-  Abort { 
-    /// Whether an abort should use timers (only relevant in stages)
-    use_stage_timers: bool 
-  },
+  Abort,
   /// Clears messages that we have stored for an abort stage
   ClearStoredAbortStage{},
   /// Toggles the camera enable/disable pin

--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -169,6 +169,26 @@ pub fn abort() -> PyResult<()> {
   Ok(())
 }
 
+/// Python exposed function that sends a message to the FC to clear the abort status.
+#[pyfunction]
+pub fn clear_abort_status() -> PyResult<()> {
+  let command = match postcard::to_allocvec(&SequenceDomainCommand::ClearAbortStatus) {
+    Ok(m) => m,
+    Err(e) => return Err(PostcardSerializationError::new_err(
+      format!("Couldn't serialize the ClearAbortStatus command: {e}")
+    )),
+  };
+
+  match SOCKET.send(&command) {
+    Ok(_) => println!("ClearAbortStatus command sent successfully to FC for processing."),
+    Err(e) => return Err(SendCommandIpcError::new_err(
+      format!("Couldn't send the ClearAbortStatus command to the FC process: {e}")
+    )),
+  }
+
+  Ok(())
+}
+
 /// Python exposed function that sends a message to the RECO board that we have launched the rocket.
 #[pyfunction]
 pub fn send_reco_launch() -> PyResult<()> {

--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -104,29 +104,6 @@ pub fn set_abort_stage(stage_name: String) -> PyResult<()> {
   Ok(())
 }
 
-/// Python exposed function that sends flight a message to abort boards based on current abort stage's safe valve states.
-#[pyfunction]
-pub fn send_sams_abort() -> PyResult<()> {
-  // we need to change vehiclestate.abort_stage.aborted from false to true since we have now aborted (fc side)
-  // also make sure to kill all sequences besides the abort stage sequence before we abort. (fc side)
-  // in the abort stage seq itself, we don't abort if we are in a "FLIGHT" abort stage.
-  let abort_command = match postcard::to_allocvec(&SequenceDomainCommand::AbortViaStage) {
-    Ok(m) => m,
-    Err(e) => return Err(PostcardSerializationError::new_err(
-      format!("Couldn't serialize the AbortViaStage command: {e}")
-    )),
-  };
-
-  match SOCKET.send(&abort_command) {
-    Ok(_) => println!("AbortViaStage sent successfully to FC for processing."),
-    Err(e) => return Err(SendCommandIpcError::new_err(
-      format!("Couldn't send the AbortViaStage command to the FC process: {e}")
-    )),
-  }
-
-  Ok(())
-}
-
 // steal default valve states function from abort stages p1 for now until gui is up?
 
 /// Python exposed function that gets the current abort stage's name
@@ -172,24 +149,15 @@ pub fn aborted_in_this_stage() -> PyResult<bool> {
     Ok(abort_condition)
 }
 
-/// A Python-exposed function which runs the abort sequence if we are in the default stage, else the abort via stage.
+/// A Python-exposed function which asks the FC to perform an immediate abort.
 #[pyfunction]
 pub fn abort() -> PyResult<()> {
-  let mut abort_command = match postcard::to_allocvec(&SequenceDomainCommand::Abort) {
-      Ok(m) => m,
-      Err(e) => return Err(PostcardSerializationError::new_err(
-        format!("Couldn't serialize the Abort command: {e}")
-      )),
-    };
-
-  if curr_abort_condition().unwrap() != "DEFAULT" {
-    abort_command = match postcard::to_allocvec(&SequenceDomainCommand::AbortViaStage) {
-      Ok(m) => m,
-      Err(e) => return Err(PostcardSerializationError::new_err(
-        format!("Couldn't serialize the AbortViaStage command: {e}")
-      )),
-    };
-  }
+  let abort_command = match postcard::to_allocvec(&SequenceDomainCommand::Abort) {
+    Ok(m) => m,
+    Err(e) => return Err(PostcardSerializationError::new_err(
+      format!("Couldn't serialize the Abort command: {e}")
+    )),
+  };
 
   match SOCKET.send(&abort_command) {
     Ok(_) => println!("Abort sent successfully."),

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -119,7 +119,6 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(interval, module)?)?;
   module.add_function(wrap_pyfunction!(create_abort_stage, module)?)?;
   module.add_function(wrap_pyfunction!(set_abort_stage, module)?)?;
-  module.add_function(wrap_pyfunction!(send_sams_abort, module)?)?;
   module.add_function(wrap_pyfunction!(curr_abort_stage, module)?)?;
   module.add_function(wrap_pyfunction!(curr_abort_condition, module)?)?;
   module.add_function(wrap_pyfunction!(aborted_in_this_stage, module)?)?;

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -116,6 +116,7 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(wait_for, module)?)?;
   module.add_function(wrap_pyfunction!(wait_until, module)?)?;
   module.add_function(wrap_pyfunction!(abort, module)?)?;
+  module.add_function(wrap_pyfunction!(clear_abort_status, module)?)?;
   module.add_function(wrap_pyfunction!(interval, module)?)?;
   module.add_function(wrap_pyfunction!(create_abort_stage, module)?)?;
   module.add_function(wrap_pyfunction!(set_abort_stage, module)?)?;

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -444,11 +444,6 @@ impl Devices {
           self.handle_setting_abort_stage(socket, stage_name, abort_stages);
         }
 
-        SequenceDomainCommand::AbortViaStage => {
-          //println!("Sending abort message to sams");
-          self.send_sams_abort(socket, sequences);
-        }
-
         SequenceDomainCommand::RecoCommand(reco_command) => {
             self.handle_sequence_reco_message(gps_handle, reco_command);
         }

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -487,6 +487,9 @@ impl Devices {
         // TODO: shouldn't we break out of the loop here? if we receive an abort
         // command why are we not flushing commands that come in after
         SequenceDomainCommand::Abort => should_abort = true,
+        SequenceDomainCommand::ClearAbortStatus => {
+          self.send_sams_clear_abort_status(socket);
+        }
       }
     }
 
@@ -734,6 +737,27 @@ impl Devices {
       }
     }
   }
+
+  /// Clears the abort status from all sams. This is used to tell a SAM that 
+  /// we are no longer in an abort state, which allows for future aborts to be performed.
+  pub(crate) fn send_sams_clear_abort_status(
+    &self,
+    socket: &UdpSocket,
+  ) {
+    for device in self.devices.iter() {
+      if device.get_board_id().starts_with("sam") {
+        let command = SamControlMessage::ClearAbortStatus;
+        if let Err(msg) =
+          self.serialize_and_send(socket, device.get_board_id(), &command)
+        {
+          println!("{}", msg);
+        } else {
+          println!("Cleared abort status from {}", device.get_board_id());
+        }
+      }
+    }
+  }
+
   pub(crate) fn send_sams_abort(
     &mut self,
     socket: &UdpSocket,

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -446,8 +446,7 @@ impl Devices {
 
         SequenceDomainCommand::AbortViaStage => {
           //println!("Sending abort message to sams");
-          self.send_sams_abort(socket, mappings, abort_stages, sequences, true);
-          // command from a sequence, so yes we want to use stage timers
+          self.send_sams_abort(socket, sequences);
         }
 
         SequenceDomainCommand::RecoCommand(reco_command) => {
@@ -743,10 +742,7 @@ impl Devices {
   pub(crate) fn send_sams_abort(
     &mut self,
     socket: &UdpSocket,
-    mappings: &Mappings,
-    abort_stages: &mut AbortStages,
     sequences: &mut Sequences,
-    use_stage_timers: bool,
   ) {
     // kill all sequences besides the abort stage sequence
     for (name, sequence) in &mut *sequences {
@@ -760,9 +756,7 @@ impl Devices {
     // send message to sams
     for device in self.devices.iter() {
       if device.get_board_id().starts_with("sam") {
-        let command = SamControlMessage::Abort {
-          use_stage_timers: use_stage_timers,
-        };
+        let command = SamControlMessage::Abort;
         // send message to this sam board
         if let Err(msg) =
           self.serialize_and_send(socket, device.get_board_id(), &command)

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -741,7 +741,7 @@ impl Devices {
   /// Clears the abort status from all sams. This is used to tell a SAM that 
   /// we are no longer in an abort state, which allows for future aborts to be performed.
   pub(crate) fn send_sams_clear_abort_status(
-    &self,
+    &mut self,
     socket: &UdpSocket,
   ) {
     for device in self.devices.iter() {
@@ -756,6 +756,9 @@ impl Devices {
         }
       }
     }
+
+    // clear aborted state for this abort stage
+    self.state.abort_stage.aborted = false;
   }
 
   pub(crate) fn send_sams_abort(
@@ -793,7 +796,7 @@ impl Devices {
   }
 
   // Clears any stored abort stages on sams
-  pub(crate) fn send_sam_clear_abort_stage(&self, socket: &UdpSocket) {
+  pub(crate) fn send_sam_clear_abort_stage(&mut self, socket: &UdpSocket) {
     for device in self.devices.iter() {
       if device.get_board_id().starts_with("sam") {
         let command = SamControlMessage::ClearStoredAbortStage {};

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -437,6 +437,9 @@ fn main() -> ! {
         FlightControlMessage::CameraEnable(should_enable) => {
           devices.send_sams_toggle_camera(&socket, should_enable)
         }
+        FlightControlMessage::ClearAbortStatus => {
+          devices.send_sams_clear_abort_status(&socket);
+        }
         _ => eprintln!(
           "Received a FlightControlMessage that is not supported: {command:#?}"
         ),

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -219,7 +219,6 @@ fn main() -> ! {
   let mut sequences: Sequences = HashMap::new();
   let mut synchronizer: Synchronizer<WyHash, LockDisabled, 1024, 500_000> =
     Synchronizer::with_params(MMAP_PATH.as_ref());
-  let mut abort_sequence: Option<Sequence> = None;
   let mut abort_stages: AbortStages = Vec::new();
 
   // Create channel for sending vehicle state to GPS worker for logging (bounded
@@ -398,15 +397,10 @@ fn main() -> ! {
 
       match command {
         FlightControlMessage::Abort => {
-          // check which type of abort should happen, abort stage or abort seq
-          if devices.get_state().abort_stage.name != "DEFAULT" {
-            devices.send_sams_abort(
-              &socket,
-              &mut sequences,
-            );
-          } else {
-            abort(&mappings, &mut sequences, &abort_sequence);
-          }
+          devices.send_sams_abort(
+            &socket,
+            &mut sequences,
+          );
         },
         FlightControlMessage::AbortStageConfig(config) => devices.create_abort_stage(&mappings, &mut abort_stages, config),
         FlightControlMessage::SetAbortStage(stage_name) => devices.handle_setting_abort_stage(&socket, stage_name, &mut abort_stages),
@@ -431,9 +425,6 @@ fn main() -> ! {
             &mut sequences,
             &mut devices,
           );
-        }
-        FlightControlMessage::Sequence(s) if s.name == "abort" => {
-          abort_sequence = Some(s)
         }
         FlightControlMessage::Sequence(ref s) => {
           sequence::execute(&mappings, s, &mut sequences)
@@ -619,18 +610,11 @@ fn main() -> ! {
     );
 
     if should_abort {
-      // check which type of abort should happen, abort stage or abort seq
-      if devices.get_state().abort_stage.name != "DEFAULT" {
-        devices.send_sams_abort(
-          &socket,
-          &mut sequences,
-        );
-      } else {
-        abort(&mappings, &mut sequences, &abort_sequence);
-      }
+      devices.send_sams_abort(
+        &socket,
+        &mut sequences,
+      );
     }
-
-    // triggers
 
     // Optional performance diagnostics for the main loop.
     if fc_perf_debug {
@@ -642,26 +626,6 @@ fn main() -> ! {
         );
       }
     }
-  }
-}
-
-fn abort(
-  mappings: &Mappings,
-  sequences: &mut Sequences,
-  abort_sequence: &Option<Sequence>,
-) {
-  if let Some(ref sequence) = abort_sequence {
-    for (name, sequence) in &mut *sequences {
-      if name != "AbortStage" {
-        if let Err(e) = sequence.kill() {
-          println!("Couldn't kill a sequence in preperation for abort, continuing normally: {e}");
-        }
-      }
-    }
-
-    sequence::execute(&mappings, sequence, sequences);
-  } else {
-    println!("Received an abort command, but no abort sequence has been set. Continuing normally...");
   }
 }
 

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -388,10 +388,7 @@ fn main() -> ! {
       // abort after SERVO_TO_FC_TIME_TO_LIVE seconds.
       devices.send_sams_abort(
         &socket,
-        &mappings,
-        &mut abort_stages,
         &mut sequences,
-        true,
       );
     }
 
@@ -405,11 +402,8 @@ fn main() -> ! {
           if devices.get_state().abort_stage.name != "DEFAULT" {
             devices.send_sams_abort(
               &socket,
-              &mappings,
-              &mut abort_stages,
               &mut sequences,
-              true,
-            ); // abort message means we use stage timers
+            );
           } else {
             abort(&mappings, &mut sequences, &abort_sequence);
           }
@@ -629,11 +623,8 @@ fn main() -> ! {
       if devices.get_state().abort_stage.name != "DEFAULT" {
         devices.send_sams_abort(
           &socket,
-          &mappings,
-          &mut abort_stages,
           &mut sequences,
-          true,
-        ); // not servo LOC, abort with stage timers
+        );
       } else {
         abort(&mappings, &mut sequences, &abort_sequence);
       }

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -843,7 +843,7 @@ fn start_abort_stage_process(
 import time
 while True:
     try:
-        if curr_abort_stage() != "FLIGHT" and aborted_in_this_stage() == False and eval(curr_abort_condition()) == True:
+        if aborted_in_this_stage() == False and eval(curr_abort_condition()) == True:
             #print("ABORTING")
             abort()
     except Exception as e:

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -38,6 +38,7 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
       abort_info.received_abort = false;
       abort_info.all_valves_aborted = false;
       abort_info.time_aborted = None;
+      clear_abort_stage_valve_states(abort_valve_states);
     },
     SamControlMessage::ClearStoredAbortStage {  } => {
       *abort_valve_states = Vec::<(ValveAction, bool)>::new();
@@ -51,6 +52,14 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
     SamControlMessage::LaunchLugDetonate(should_enable) => {
       toggle_launch_lug_detonate(should_enable);
     },
+  }
+}
+
+/// Clears the abort stage valve states by setting all aborted flags for valves 
+/// to false.
+fn clear_abort_stage_valve_states(abort_valve_states: &mut Vec<(ValveAction, bool)>) {
+  for (_, aborted) in abort_valve_states {
+    *aborted = false;
   }
 }
 

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -29,10 +29,15 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
         &mut abort_info.received_abort,
       );
     },
-    SamControlMessage::Abort {} => {
+    SamControlMessage::Abort => {
       abort_info.time_aborted = Some(Instant::now()); // do this before so timer instantly starts, also to prevent reading stale timer
       safe_valves(abort_valve_states, &abort_info.time_aborted, &mut abort_info.all_valves_aborted);
       abort_info.received_abort = true; 
+    },
+    SamControlMessage::ClearAbortStatus => {
+      abort_info.received_abort = false;
+      abort_info.all_valves_aborted = false;
+      abort_info.time_aborted = None;
     },
     SamControlMessage::ClearStoredAbortStage {  } => {
       *abort_valve_states = Vec::<(ValveAction, bool)>::new();

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -66,31 +66,35 @@ pub fn check_valve_abort_timers(abort_valve_states: &mut Vec<(ValveAction, bool)
 // safe the valves by going to safe states (if abort stage is set) or depowering valves
 pub fn safe_valves(abort_valve_states: &mut Vec<(ValveAction, bool)>, time_aborted: &Option<Instant>, all_valves_aborted: &mut bool) {
   let mut non_aborted_valve_exists = false;
-  // check if an abort stage has been set (indirectly) by seeing if we have predefined abort valve states
+
+  // if we have not aborted all valves, valves still need to be safed
   if !*all_valves_aborted {
-    for (valve_info, aborted) in abort_valve_states {
+    // check if an abort stage has been set by seeing if we have any predefined abort valve states
+    if !abort_valve_states.is_empty() {
+      for (valve_info, aborted) in abort_valve_states {
 
-      // abort the valve if we want an instant abort OR if our timer is up and we haven't aborted yet
-      if !*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer  {
-        actuate_valve(valve_info.channel_num, valve_info.powered);
+        // abort the valve if we want an instant abort OR if our timer is up and we haven't aborted yet
+        if !*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer  {
+          actuate_valve(valve_info.channel_num, valve_info.powered);
 
-        // mark this valve as aborted 
-        *aborted = true;
+          // mark this valve as aborted 
+          *aborted = true;
+        }
+
+        if !*aborted {
+          non_aborted_valve_exists = true;
+        } 
       }
+    } else { 
+      // we can assume that no abort stage has been set, therefore we just depower all valves
+      for i in 1..7 {
+        actuate_valve(i, false);
+      }
+    }
 
-      if !*aborted {
-        non_aborted_valve_exists = true;
-      } 
-    }
-  } else { 
-    // we can assume that no abort stage has been set, therefore we just depower. 
-    // also enter this case in a servo to fc (mc to pad) disconnect
-    for i in 1..7 {
-      actuate_valve(i, false); // turn off all valves
-    }
+    // if no non-aborted valves exist, we have aborted all valves
+    *all_valves_aborted = !non_aborted_valve_exists;
   }
-
-  *all_valves_aborted = !non_aborted_valve_exists;
 }
 
 pub fn init_gpio() {

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -29,9 +29,9 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
         &mut abort_info.received_abort,
       );
     },
-    SamControlMessage::Abort { use_stage_timers } => {
+    SamControlMessage::Abort {} => {
       abort_info.time_aborted = Some(Instant::now()); // do this before so timer instantly starts, also to prevent reading stale timer
-      safe_valves(abort_valve_states, &abort_info.time_aborted, &mut abort_info.all_valves_aborted, use_stage_timers);
+      safe_valves(abort_valve_states, &abort_info.time_aborted, &mut abort_info.all_valves_aborted);
       abort_info.received_abort = true; 
     },
     SamControlMessage::ClearStoredAbortStage {  } => {
@@ -60,18 +60,18 @@ fn store_abort_valve_states(desired_valve_states: &Vec<ValveAction>, stored_valv
 
 // Calls safe_valves under the hood, exists primarily for naming convention logic 
 pub fn check_valve_abort_timers(abort_valve_states: &mut Vec<(ValveAction, bool)>, all_valves_aborted: &mut bool, time_aborted: &Option<Instant>) {
-  safe_valves(abort_valve_states, time_aborted, all_valves_aborted, true);
+  safe_valves(abort_valve_states, time_aborted, all_valves_aborted);
 }
 
 // safe the valves by going to safe states (if abort stage is set) or depowering valves
-pub fn safe_valves(abort_valve_states: &mut Vec<(ValveAction, bool)>, time_aborted: &Option<Instant>, all_valves_aborted: &mut bool, use_stage_timers: bool) {
+pub fn safe_valves(abort_valve_states: &mut Vec<(ValveAction, bool)>, time_aborted: &Option<Instant>, all_valves_aborted: &mut bool) {
   let mut non_aborted_valve_exists = false;
   // check if an abort stage has been set (indirectly) by seeing if we have predefined abort valve states
-  if use_stage_timers && !*all_valves_aborted {
+  if !*all_valves_aborted {
     for (valve_info, aborted) in abort_valve_states {
 
       // abort the valve if we want an instant abort OR if our timer is up and we haven't aborted yet
-      if !use_stage_timers || (!*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer)  {
+      if !*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer  {
         actuate_valve(valve_info.channel_num, valve_info.powered);
 
         // mark this valve as aborted 
@@ -117,7 +117,7 @@ pub fn init_gpio() {
   }
 
   // turn off all valves
-  safe_valves(&mut Vec::new(), &None, &mut false, false);
+  safe_valves(&mut Vec::new(), &None, &mut false);
   // initally measure valve currents on valves 1, 3, and 5 for rev4
   reset_valve_current_sel_pins();
 }

--- a/sam/src/communication.rs
+++ b/sam/src/communication.rs
@@ -11,8 +11,6 @@ use std::{
 };
 
 use crate::{command::{execute, check_valve_abort_timers}, state::{AbortInfo, ConnectData}, SamVersion, FC_ADDR, CACHED_FC_ADDRESS};
-use std::thread;
-use std::net::Ipv4Addr;
 
 // const FC_ADDR: &str = "server-01";
 // const FC_ADDR: &str = "flight";

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -218,10 +218,8 @@ fn main_loop(mut data: MainLoopData) -> State {
 
 fn abort(mut data: AbortData) -> State {
   fail!("Aborting goodbye!");
-  // figure out whether we need to use abort stages or not 
-  let use_abort_stages = !data.abort_valve_states.is_empty();
-  // abort valves, either depowering all of them if we do not have any saved abort stage safe states or referring to the saved abort stage safe states
-  safe_valves(&mut data.abort_valve_states, &data.abort_info.time_aborted, &mut data.abort_info.all_valves_aborted, use_abort_stages);
+  // abort valves
+  safe_valves(&mut data.abort_valve_states, &data.abort_info.time_aborted, &mut data.abort_info.all_valves_aborted);
   // reset ADC pin muxing
   reset_adcs(&mut data.adcs);
   // reset pins that select which valve currents are measured from valve driver

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -191,7 +191,7 @@ fn main_loop(mut data: MainLoopData) -> State {
   // if there are commands, do them!
   check_and_execute(&data.my_command_socket, &mut data.abort_info, &mut data.abort_valve_states);
 
-  // check up on abort valve timers if we have received an abort an all valves have not been aborted
+  // check up on abort valve timers if we have received an abort and all valves have not been aborted
   if data.abort_info.received_abort && !data.abort_info.all_valves_aborted {
     check_valve_abort_timers(&mut data.abort_valve_states, &mut data.abort_info.all_valves_aborted, &data.abort_info.time_aborted);
   }

--- a/servo/src/server/flight.rs
+++ b/servo/src/server/flight.rs
@@ -208,13 +208,9 @@ impl FlightComputer {
     }
   }
 
-  /// Sends a comprehensive update of mappings, triggers, and abort sequence to
-  /// flight.
+  /// Sends a comprehensive update of mappings and triggers to flight.
   pub async fn update(&mut self) -> anyhow::Result<()> {
     self.send_mappings().await?;
-
-    // TODO: send triggers and abort sequence automatically
-
     Ok(())
   }
 }

--- a/servo/src/server/routes/sequence.rs
+++ b/servo/src/server/routes/sequence.rs
@@ -88,19 +88,6 @@ pub async fn save_sequence(
     )
     .map_err(internal)?;
 
-  // if the incoming sequence is the abort sequence, immediately send it over to
-  // flight to be saved, _not run_.
-  if request.name == "abort" {
-    if let Some(flight) = shared.flight.0.lock().await.as_mut() {
-      let sequence = Sequence {
-        name: request.name,
-        script: decoded_script,
-      };
-
-      flight.send_sequence(sequence).await.map_err(internal)?;
-    }
-  }
-
   Ok(())
 }
 
@@ -165,15 +152,6 @@ pub async fn run_sequence(
     .map_err(bad_request)?;
 
   if let Some(flight) = shared.flight.0.lock().await.as_mut() {
-    // special case for abort sequence, because sending it over just saves it
-    // so we need to send an actual abort control message if we want to run it
-    if sequence.name == "abort" {
-      flight.abort().await.map_err(internal)?;
-
-      return Ok(());
-    }
-
-    // otherwise, send the sequence as normal to the flight computer
     flight.send_sequence(sequence).await.map_err(internal)?;
   } else {
     return Err(internal("flight computer not connected"));


### PR DESCRIPTION
Code changes for abort stage refactor / cleanup. Main changes involve:
- `abort()` is deprecated, and will no longer run if the ABORT button on the GUI is clicked
- `clear_abort_status()` allows for clearing the abort status of the system via sequences, which is useful once a system enters an aborted state and we then want to continue testing without restarting software
- one path for all aborts hit on the flight computer, which is the `send_sams_abort()`, which hits the same command path for SAMs

<p>Combination of <a href="https://github.com/gt-space/luna/compare/main...dev/AVI-291/abort-stage-cleanup?expand=1">dev/AVI-291/abort-stage-cleanup</a>, <a href="https://github.com/gt-space/luna/compare/main...dev/AVI-291/abort-stage-cleanup?expand=1">dev/AVI-293/umbilical-care-patch</a>, and <a href="https://github.com/gt-space/luna/compare/dev/AVI-294/disable-fcb-sensors?expand=1">dev/AVI-294/disable-fc-sensors</a>.</p>

Testing notes:
Below test cases were run with Servo + Flight on an mc laptop (server-01) directly connected to sam-01 (valve connected on ch5). All versions of software are off of dev/AVI-297/darcy-wdr.

**Case 1: Umbilical disconnect in default abort stage** 

Expected behavior: An abort in the default abort stage should simply result in all SAMs de-powering their valves. 

Observed behavior: Disconnected ethernet between mc laptop and sam-01 and heard nominal click on valve. 

**Case 2: Umbilical disconnect in custom abort stage (no timer)**

Custom abort stage: 

| valve name | desired state | timer |
| --- | --- | --- |
| valve5 | OPEN | 0 |

Expected behavior: An abort in a custom abort stage should abide by the abort stage. For this specific abort stage, we expect valve5 to transition to OPEN immediately.  

Observed behavior: Disconnected ethernet between mc laptop and sam-01 and heard nominal click on valve. 

**Case 3: Umbilical disconnect in custom abort stage (with timer)**

Custom abort stage: 

| valve name | desired state | timer |
| --- | --- | --- |
| valve5 | OPEN | 5 |

Expected behavior: An abort in a custom abort stage should abide by the abort stage. For this specific abort stage, we expect valve5 to transition to OPEN after 5 seconds.  

Observed behavior: Disconnected ethernet between mc laptop and sam-01 and heard nominal click on valve after 5 seconds. 

**Case 4: Sequence with unsupported `send_sams_abort()`** 

Sequence:

```python
send_sams_abort()
```

Expected behavior: A sequence with an unsupported function call should error out.  

Observed behavior: Sequence errored out. 

Note: We are removing this function because it has the exact same functionality as  `abort()` .

**Case 4: Sequence with `abort()` while in default abort stage**

Sequence:

```python
abort()
```

Expected behavior: `abort()` should behave exactly like clicking the ABORT button in the GUI or a loss-of-comms abort. This behavior, while in the default abort stage, is instantaneous de-powering of valves.

Observed behavior: Observed valve click upon dispatch of sequence. 

**Case 5: Sequence with `abort()` , sequence with `clear_abort_status()` , `abort()`again, all while in default abort stage**

Sequences:

```python
abort()
```

```python
clear_abort_status()
```

Expected behavior: `abort()` should instantly de-power valves while in the DEFAULT abort stage. After `clear_abort_status()` the abort status on SAMs should be cleared, thus a subsequent `abort()` should show the SAM aborting again. 

Observed behavior: Observed valve click upon initial dispatch of `abort()` sequence and valve click after second dispatch of `abort()` which was after dispatch of `clear_abort_status()` .

TODO: There is no way to replicate the `clear_abort_status()` via the GUI (only via sequences). This should be changed. 

**Case 6: Sequence with `abort()` , sequence with `clear_abort_status()` , `abort()`again, all while in custom abort stage**

Sequences:

```python
abort()
```

```python
clear_abort_status()
```

Custom abort stage:

| valve name | desired state | timer |
| --- | --- | --- |
| valve5 | OPEN | 5 |

Expected behavior: `abort()` should instantly de-power valves while in the DEFAULT abort stage. After `clear_abort_status()` the abort status on SAMs should be cleared, thus a subsequent `abort()` should show the SAM aborting again. 

Observed behavior: Observed valve click upon initial dispatch of `abort()` sequence and valve click after second dispatch of `abort()` which was after dispatch of `clear_abort_status()` .

**Case 7: Clicking ABORT button via GUI**

Custom abort stage: 

| valve name | desired state | timer |
| --- | --- | --- |
| valve5 | OPEN | 5 |

Expected behavior: Clicking the ABORT button via GUI should have the exact same behavior as calling `abort()` via sequences or a loss-of-comms abort. In the default stage, we should see instantaneous valve de-powering. In custom abort stages, we should see behavior that abides by the abort stage.  

Observed behavior: While in DEFAULT abort stage, heard valve click instantaneously. While in custom abort stage, observed valve click after 5 seconds. 

**Case 8: Sequence named `abort` is not automatically sent to Flight, and no abort behavior results in the abort sequence being run**

Expected behavior: When submitting (not dispatching) a sequence named `abort` we should not receive this sequence on Flight. Additionally, no abort  should result in a sequence named `abort` being run. 

Observed behavior: Submitted a sequence named `abort` and saw no received message on Flight. Clicked the ABORT button on GUI and nominal abort behavior proceeded (not running the `abort()` )