### PR TITLE
Try to reconnect to servo even on umbilical don't care

### DIFF
--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -342,10 +342,10 @@ pub fn sam_camera_toggle(should_enable: bool) -> PyResult<()> {
   
   Ok(())
 }
-/// Python exposed function that tells the FC to ignore servo disconnects if 
-/// enabled is false, else to monitor servo disconnects.
+/// Python exposed function that tells the FC to abort the system if enabled is
+/// true, else to NOT abort the system. 
 #[pyfunction]
-pub fn set_servo_disconnect_monitoring(enabled: bool) -> PyResult<()> {
+pub fn servo_disconnect_abort(enabled: bool) -> PyResult<()> {
   let command = match postcard::to_allocvec(
     &SequenceDomainCommand::SetServoDisconnectMonitoring { enabled },
   ) {

--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -345,7 +345,7 @@ pub fn sam_camera_toggle(should_enable: bool) -> PyResult<()> {
 /// Python exposed function that tells the FC to abort the system if enabled is
 /// true, else to NOT abort the system. 
 #[pyfunction]
-pub fn servo_disconnect_abort(enabled: bool) -> PyResult<()> {
+pub fn set_servo_disconnect_abort(enabled: bool) -> PyResult<()> {
   let command = match postcard::to_allocvec(
     &SequenceDomainCommand::SetServoDisconnectMonitoring { enabled },
   ) {

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -129,7 +129,7 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(reco_recvd_launch, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_arm, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_detonate, module)?)?;
-  module.add_function(wrap_pyfunction!(servo_disconnect_abort, module)?)?;
+  module.add_function(wrap_pyfunction!(set_servo_disconnect_abort, module)?)?;
   module.add_function(wrap_pyfunction!(sam_camera_toggle, module)?)?;
 
   Ok(())

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -129,7 +129,7 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(reco_recvd_launch, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_arm, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_detonate, module)?)?;
-  module.add_function(wrap_pyfunction!(set_servo_disconnect_monitoring, module)?)?;
+  module.add_function(wrap_pyfunction!(servo_disconnect_abort, module)?)?;
   module.add_function(wrap_pyfunction!(sam_camera_toggle, module)?)?;
 
   Ok(())

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -150,9 +150,6 @@ pub(crate) struct Devices {
   /// Whether the FC should actively monitor servo disconnects and react to
   /// them.
   monitor_servo_disconnects: bool,
-  /// Whether we are still actively communicating with servo (pulling data and
-  /// pushing telemetry).
-  servo_communication_enabled: bool,
 }
 
 impl Devices {
@@ -163,7 +160,6 @@ impl Devices {
       state: VehicleState::new(),
       last_updates: HashMap::new(),
       monitor_servo_disconnects: true,
-      servo_communication_enabled: true,
     }
   }
 
@@ -488,12 +484,6 @@ impl Devices {
         }
         SequenceDomainCommand::SetServoDisconnectMonitoring { enabled } => {
           self.monitor_servo_disconnects = enabled;
-          if enabled {
-            // When monitoring is re-enabled, also allow the FC to resume
-            // communicating with servo. The main loop will handle
-            // reconnecting on the next pull attempt if needed.
-            self.servo_communication_enabled = true;
-          }
           println!(
             "Servo disconnect monitoring {}.",
             if enabled { "enabled" } else { "disabled" }
@@ -929,16 +919,6 @@ impl Devices {
   /// Returns whether the FC should monitor servo disconnects.
   pub(crate) fn monitor_servo_disconnects(&self) -> bool {
     self.monitor_servo_disconnects
-  }
-
-  /// Returns whether the FC is currently communicating with servo.
-  pub(crate) fn servo_communication_enabled(&self) -> bool {
-    self.servo_communication_enabled
-  }
-
-  /// Sets whether the FC should communicate with servo.
-  pub(crate) fn set_servo_communication_enabled(&mut self, enabled: bool) {
-    self.servo_communication_enabled = enabled;
   }
 
   pub(crate) fn set_abort_stage(&mut self, stage: &AbortStage) {

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -147,9 +147,8 @@ pub(crate) struct Devices {
   devices: Vec<Device>,
   state: VehicleState,
   last_updates: HashMap<String, Instant>,
-  /// Whether the FC should actively monitor servo disconnects and react to
-  /// them.
-  monitor_servo_disconnects: bool,
+  /// Whether the FC should abort on servo disconnect.
+  servo_disconnect_abort_enabled: bool,
 }
 
 impl Devices {
@@ -159,7 +158,7 @@ impl Devices {
       devices: Vec::new(),
       state: VehicleState::new(),
       last_updates: HashMap::new(),
-      monitor_servo_disconnects: true,
+      servo_disconnect_abort_enabled: true,
     }
   }
 
@@ -483,9 +482,9 @@ impl Devices {
           self.send_sams_toggle_camera(socket, should_enable);
         }
         SequenceDomainCommand::SetServoDisconnectMonitoring { enabled } => {
-          self.monitor_servo_disconnects = enabled;
+          self.servo_disconnect_abort_enabled = enabled;
           println!(
-            "Servo disconnect monitoring {}.",
+            "Abort on servo disconnect set to {}.",
             if enabled { "enabled" } else { "disabled" }
           );
         }
@@ -917,8 +916,8 @@ impl Devices {
   }
 
   /// Returns whether the FC should monitor servo disconnects.
-  pub(crate) fn monitor_servo_disconnects(&self) -> bool {
-    self.monitor_servo_disconnects
+  pub(crate) fn servo_disconnect_abort_enabled(&self) -> bool {
+    self.servo_disconnect_abort_enabled
   }
 
   pub(crate) fn set_abort_stage(&mut self, stage: &AbortStage) {

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -360,17 +360,12 @@ fn main() -> ! {
     let loop_start = Instant::now();
 
     // Pull any new message from servo if we are still communicating with it.
-    let servo_message = if devices.servo_communication_enabled() {
-      get_servo_data(
-        &mut servo_stream,
-        &mut servo_address,
-        &mut last_received_from_servo,
-        &mut aborted,
-        &mut devices,
-      )
-    } else {
-      None
-    };
+    let servo_message = get_servo_data(
+      &mut servo_stream,
+      &mut servo_address,
+      &mut last_received_from_servo,
+      &mut aborted,
+    );
 
     let servo_disconnect_abort_active = devices.monitor_servo_disconnects();
 
@@ -507,9 +502,7 @@ fn main() -> ! {
     }
 
     let now = Instant::now();
-    let servo_comm_enabled = devices.servo_communication_enabled();
-    let send_umbilical = servo_comm_enabled
-      && now.duration_since(last_sent_to_servo) > FC_TO_SERVO_RATE;
+    let send_umbilical = now.duration_since(last_sent_to_servo) > FC_TO_SERVO_RATE;
     let send_radio = now.duration_since(last_sent_radio_to_servo) > FC_TO_SERVO_RADIO_RATE;
 
     if send_umbilical {
@@ -695,16 +688,7 @@ fn get_servo_data(
   servo_address: &mut SocketAddr,
   last_received_from_servo: &mut Instant,
   aborted: &mut bool,
-  devices: &mut Devices,
 ) -> Option<FlightControlMessage> {
-  // If we've been instructed to permanently stop communicating with servo after
-  // a disconnect, short-circuit immediately.
-  if !devices.servo_communication_enabled() {
-    return None;
-  }
-
-  let monitor_servo_disconnects = devices.monitor_servo_disconnects();
-
   match servo::pull(servo_stream) {
     Ok(message) => {
       *last_received_from_servo = Instant::now();
@@ -715,36 +699,26 @@ fn get_servo_data(
 
       match e {
         ServoError::ServoDisconnected => {
-          if monitor_servo_disconnects {
-            eprintln!("Attempting to reconnect to servo... ");
+          eprintln!("Attempting to reconnect to servo... ");
 
-            match servo::establish(
-              &SERVO_SOCKET_ADDRESSES,
-              Some(servo_address),
-              SERVO_RECONNECT_RETRY_COUNT,
-              SERVO_RECONNECT_TIMEOUT,
-            ) {
-              Ok(s) => {
-                (*servo_stream, *servo_address) = s;
-                *last_received_from_servo = Instant::now();
-                *aborted = false;
-                eprintln!("Connection successfully re-established.");
-              }
-              Err(e) => {
-                eprintln!(
-                  "Connection could not be re-established: {e}. Continuing..."
-                );
-              }
-            };
-          } else {
-            eprintln!(
-              "Servo disconnected, but monitoring is disabled; ceasing further communication with servo."
-            );
-            // Once we've seen a disconnect with monitoring disabled, stop all
-            // future attempts to reconnect to, pull from, or push
-            // telemetry to servo.
-            devices.set_servo_communication_enabled(false);
-          }
+          match servo::establish(
+            &SERVO_SOCKET_ADDRESSES,
+            Some(servo_address),
+            SERVO_RECONNECT_RETRY_COUNT,
+            SERVO_RECONNECT_TIMEOUT,
+          ) {
+            Ok(s) => {
+              (*servo_stream, *servo_address) = s;
+              *last_received_from_servo = Instant::now();
+              *aborted = false;
+              eprintln!("Connection successfully re-established.");
+            }
+            Err(e) => {
+              eprintln!(
+                "Connection could not be re-established: {e}. Continuing..."
+              );
+            }
+          };
         }
         ServoError::DeserializationFailed(_) => {}
         ServoError::TransportFailed(_) => {}

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -367,10 +367,8 @@ fn main() -> ! {
       &mut aborted,
     );
 
-    let servo_disconnect_abort_active = devices.monitor_servo_disconnects();
-
     if !aborted
-      && servo_disconnect_abort_active
+      && devices.servo_disconnect_abort_enabled()
       && (Instant::now().duration_since(last_received_from_servo)
         > SERVO_TO_FC_TIME_TO_LIVE)
     {


### PR DESCRIPTION
This change makes the flight-computer still attempt to reconnect with Servo if `servo_disconnect_abort_enabled=false` and we are disconnected from Servo. This means that if the flight-computer disconnects from Servo when `servo_disconnect_abort_enabled=false`, the only change in behavior compared to when `servo_disconnect_abort_enabled=true` is that the system will not enter an abort state, which is expected as `servo_disconnect_abort_enabled` should only be set to `false` in the launch sequence. The sequence function has been updated from `set_servo_disconnect_monitoring()` to `set_servo_disconnect_abort()`. 

Testing:
This was tested at Darcy WDR with launch sequence tests where `servo_disconnect_abort_enabled` was set to `false` and umbilical was disconnected, and upon reconnection of umbilical the flight-computer reconnects to Servo successfully. 