### PR TITLE
Dev/avi 297/darcy wdr

### DIFF
--- a/common/src/comm.rs
+++ b/common/src/comm.rs
@@ -596,6 +596,9 @@ pub enum FlightControlMessage {
   /// Instructs the flight computer to run an immediate abort.
   Abort,
 
+  /// Instructs the flight computer to clear the abort status.
+  ClearAbortStatus,
+
   /// Instructs the flight computer to tell SAMs to toggle camera en/dis
   CameraEnable(bool), // true for enable, false for disable
 

--- a/common/src/comm/flight.rs
+++ b/common/src/comm/flight.rs
@@ -79,11 +79,7 @@ pub enum SequenceDomainCommand {
     stage_name: String,
   },
 
-  /// Tells FC to tell sams to abort via the stage's "safe" valve states.
-  /// Different from Abort message, which runs the abort sequence
-  AbortViaStage,
-
-  /// Tells the FC to run the abort sequence.
+  /// Tells the FC to perform an immediate abort.
   Abort,
 
   /// Tells the FC whether to monitor servo disconnects (and react) or ignore them.

--- a/common/src/comm/flight.rs
+++ b/common/src/comm/flight.rs
@@ -82,6 +82,9 @@ pub enum SequenceDomainCommand {
   /// Tells the FC to perform an immediate abort.
   Abort,
 
+  /// Tells the FC to clear the abort status.
+  ClearAbortStatus,
+
   /// Tells the FC whether to monitor servo disconnects (and react) or ignore them.
   ///
   /// When `enabled` is false, the FC should not abort on servo disconnect timeouts,

--- a/common/src/comm/sam.rs
+++ b/common/src/comm/sam.rs
@@ -177,6 +177,9 @@ pub enum SamControlMessage {
   Abort,
   /// Clears messages that we have stored for an abort stage
   ClearStoredAbortStage{},
+  /// Clears the abort status. This is used to tell a SAM that we are 
+  /// no longer in an abort state, which allows for future aborts to be performed.
+  ClearAbortStatus,
   /// Toggles the camera enable/disable pin
   CameraEnable(bool), // true for enable, false for disable
   /// Toggles the launch lug enable/disable pin

--- a/common/src/comm/sam.rs
+++ b/common/src/comm/sam.rs
@@ -174,10 +174,7 @@ pub enum SamControlMessage {
     valve_states: Vec<ValveAction>,
   },
   /// Tells a board to abort.
-  Abort { 
-    /// Whether an abort should use timers (only relevant in stages)
-    use_stage_timers: bool 
-  },
+  Abort,
   /// Clears messages that we have stored for an abort stage
   ClearStoredAbortStage{},
   /// Toggles the camera enable/disable pin

--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -169,6 +169,26 @@ pub fn abort() -> PyResult<()> {
   Ok(())
 }
 
+/// Python exposed function that sends a message to the FC to clear the abort status.
+#[pyfunction]
+pub fn clear_abort_status() -> PyResult<()> {
+  let command = match postcard::to_allocvec(&SequenceDomainCommand::ClearAbortStatus) {
+    Ok(m) => m,
+    Err(e) => return Err(PostcardSerializationError::new_err(
+      format!("Couldn't serialize the ClearAbortStatus command: {e}")
+    )),
+  };
+
+  match SOCKET.send(&command) {
+    Ok(_) => println!("ClearAbortStatus command sent successfully to FC for processing."),
+    Err(e) => return Err(SendCommandIpcError::new_err(
+      format!("Couldn't send the ClearAbortStatus command to the FC process: {e}")
+    )),
+  }
+
+  Ok(())
+}
+
 /// Python exposed function that sends a message to the RECO board that we have launched the rocket.
 #[pyfunction]
 pub fn send_reco_launch() -> PyResult<()> {

--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -104,29 +104,6 @@ pub fn set_abort_stage(stage_name: String) -> PyResult<()> {
   Ok(())
 }
 
-/// Python exposed function that sends flight a message to abort boards based on current abort stage's safe valve states.
-#[pyfunction]
-pub fn send_sams_abort() -> PyResult<()> {
-  // we need to change vehiclestate.abort_stage.aborted from false to true since we have now aborted (fc side)
-  // also make sure to kill all sequences besides the abort stage sequence before we abort. (fc side)
-  // in the abort stage seq itself, we don't abort if we are in a "FLIGHT" abort stage.
-  let abort_command = match postcard::to_allocvec(&SequenceDomainCommand::AbortViaStage) {
-    Ok(m) => m,
-    Err(e) => return Err(PostcardSerializationError::new_err(
-      format!("Couldn't serialize the AbortViaStage command: {e}")
-    )),
-  };
-
-  match SOCKET.send(&abort_command) {
-    Ok(_) => println!("AbortViaStage sent successfully to FC for processing."),
-    Err(e) => return Err(SendCommandIpcError::new_err(
-      format!("Couldn't send the AbortViaStage command to the FC process: {e}")
-    )),
-  }
-
-  Ok(())
-}
-
 // steal default valve states function from abort stages p1 for now until gui is up?
 
 /// Python exposed function that gets the current abort stage's name
@@ -172,24 +149,15 @@ pub fn aborted_in_this_stage() -> PyResult<bool> {
     Ok(abort_condition)
 }
 
-/// A Python-exposed function which runs the abort sequence if we are in the default stage, else the abort via stage.
+/// A Python-exposed function which asks the FC to perform an immediate abort.
 #[pyfunction]
 pub fn abort() -> PyResult<()> {
-  let mut abort_command = match postcard::to_allocvec(&SequenceDomainCommand::Abort) {
-      Ok(m) => m,
-      Err(e) => return Err(PostcardSerializationError::new_err(
-        format!("Couldn't serialize the Abort command: {e}")
-      )),
-    };
-
-  if curr_abort_condition().unwrap() != "DEFAULT" {
-    abort_command = match postcard::to_allocvec(&SequenceDomainCommand::AbortViaStage) {
-      Ok(m) => m,
-      Err(e) => return Err(PostcardSerializationError::new_err(
-        format!("Couldn't serialize the AbortViaStage command: {e}")
-      )),
-    };
-  }
+  let abort_command = match postcard::to_allocvec(&SequenceDomainCommand::Abort) {
+    Ok(m) => m,
+    Err(e) => return Err(PostcardSerializationError::new_err(
+      format!("Couldn't serialize the Abort command: {e}")
+    )),
+  };
 
   match SOCKET.send(&abort_command) {
     Ok(_) => println!("Abort sent successfully."),

--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -342,10 +342,10 @@ pub fn sam_camera_toggle(should_enable: bool) -> PyResult<()> {
   
   Ok(())
 }
-/// Python exposed function that tells the FC to ignore servo disconnects if 
-/// enabled is false, else to monitor servo disconnects.
+/// Python exposed function that tells the FC to abort the system if enabled is
+/// true, else to NOT abort the system. 
 #[pyfunction]
-pub fn set_servo_disconnect_monitoring(enabled: bool) -> PyResult<()> {
+pub fn servo_disconnect_abort(enabled: bool) -> PyResult<()> {
   let command = match postcard::to_allocvec(
     &SequenceDomainCommand::SetServoDisconnectMonitoring { enabled },
   ) {

--- a/common/src/sequence/func.rs
+++ b/common/src/sequence/func.rs
@@ -345,7 +345,7 @@ pub fn sam_camera_toggle(should_enable: bool) -> PyResult<()> {
 /// Python exposed function that tells the FC to abort the system if enabled is
 /// true, else to NOT abort the system. 
 #[pyfunction]
-pub fn servo_disconnect_abort(enabled: bool) -> PyResult<()> {
+pub fn set_servo_disconnect_abort(enabled: bool) -> PyResult<()> {
   let command = match postcard::to_allocvec(
     &SequenceDomainCommand::SetServoDisconnectMonitoring { enabled },
   ) {

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -119,7 +119,6 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(interval, module)?)?;
   module.add_function(wrap_pyfunction!(create_abort_stage, module)?)?;
   module.add_function(wrap_pyfunction!(set_abort_stage, module)?)?;
-  module.add_function(wrap_pyfunction!(send_sams_abort, module)?)?;
   module.add_function(wrap_pyfunction!(curr_abort_stage, module)?)?;
   module.add_function(wrap_pyfunction!(curr_abort_condition, module)?)?;
   module.add_function(wrap_pyfunction!(aborted_in_this_stage, module)?)?;

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -116,6 +116,7 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(wait_for, module)?)?;
   module.add_function(wrap_pyfunction!(wait_until, module)?)?;
   module.add_function(wrap_pyfunction!(abort, module)?)?;
+  module.add_function(wrap_pyfunction!(clear_abort_status, module)?)?;
   module.add_function(wrap_pyfunction!(interval, module)?)?;
   module.add_function(wrap_pyfunction!(create_abort_stage, module)?)?;
   module.add_function(wrap_pyfunction!(set_abort_stage, module)?)?;

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -129,7 +129,7 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(reco_recvd_launch, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_arm, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_detonate, module)?)?;
-  module.add_function(wrap_pyfunction!(servo_disconnect_abort, module)?)?;
+  module.add_function(wrap_pyfunction!(set_servo_disconnect_abort, module)?)?;
   module.add_function(wrap_pyfunction!(sam_camera_toggle, module)?)?;
 
   Ok(())

--- a/common/src/sequence/mod.rs
+++ b/common/src/sequence/mod.rs
@@ -129,7 +129,7 @@ fn sequences(py: Python<'_>, module: &PyModule) -> PyResult<()> {
   module.add_function(wrap_pyfunction!(reco_recvd_launch, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_arm, module)?)?;
   module.add_function(wrap_pyfunction!(launch_lug_detonate, module)?)?;
-  module.add_function(wrap_pyfunction!(set_servo_disconnect_monitoring, module)?)?;
+  module.add_function(wrap_pyfunction!(servo_disconnect_abort, module)?)?;
   module.add_function(wrap_pyfunction!(sam_camera_toggle, module)?)?;
 
   Ok(())

--- a/flight2/README.md
+++ b/flight2/README.md
@@ -34,10 +34,10 @@ magnetometer while leaving the barometer enabled:
 cargo run -p flight-computer --release -- disable-imu disable-magnetometer
 ```
 
-### Desktop mode (no FC-local SPI sensor workers)
+### Desktop mode (no GPS/RECO or FC-local sensor workers)
 
-Use the `desktop` subcommand to skip starting the GPS/RECO, MAG+BAR, and
-IMU+ADC workers. This is useful when running on a computer that is not an
+Use the `desktop` command to skip starting the GPS/RECO worker and the
+MAG+BAR and IMU+ADC workers. This is useful when running on a computer that is not an
 embedded device (ie. MC laptops, meerkats, etc).
 
 ```bash

--- a/flight2/README.md
+++ b/flight2/README.md
@@ -16,18 +16,32 @@ From `**flight2/**`:
 cargo run --release
 ```
 
+### Disable FC-local sensors
+
+The flight computer accepts stackable command words to disable individual
+workers and FC-local sensors without touching their hardware interfaces:
+
+```bash
+cargo run -p flight-computer --release -- disable-gps
+cargo run -p flight-computer --release -- disable-imu
+cargo run -p flight-computer --release -- disable-magnetometer disable-barometer
+```
+
+These can be combined in any order. For example, this disables both the IMU and
+magnetometer while leaving the barometer enabled:
+
+```bash
+cargo run -p flight-computer --release -- disable-imu disable-magnetometer
+```
+
 ### Desktop mode (no FC-local SPI sensor workers)
 
-Use the `desktop` subcommand to skip starting the MAG+BAR and IMU+ADC workers (useful on a dev machine without that hardware):
+Use the `desktop` subcommand to skip starting the GPS/RECO, MAG+BAR, and
+IMU+ADC workers. This is useful when running on a computer that is not an
+embedded device (ie. MC laptops, meerkats, etc).
 
 ```bash
 cargo run -p flight-computer --release -- desktop
-```
-
-Global options still work after the subcommand, for example:
-
-```bash
-cargo run -p flight-computer --release -- desktop --print-gps
 ```
 
 ### Build only, then run
@@ -38,11 +52,13 @@ cargo run -p flight-computer --release -- desktop --print-gps
 cargo build -p flight-computer --release
 ```
 
-Then run the release binary from the workspace root (artifact path is under `target/release/`):
+Then run the release binary from the workspace root (artifact path is under `target/release/`). A few examples of some subcommands that you can run the binary with are also listed:
 
 ```bash
 ./target/release/flight-computer
 ./target/release/flight-computer desktop
+./target/release/flight-computer disable-gps disable-imu
+./target/release/flight-computer disable-imu disable-magnetometer
 ```
 
 If you built from inside `flight2/`, the binary is still emitted at the workspace `target/` when this crate is part of the workspace (default layout: `../target/release/flight-computer` relative to `flight2/`).

--- a/flight2/README.md
+++ b/flight2/README.md
@@ -62,3 +62,60 @@ Then run the release binary from the workspace root (artifact path is under `tar
 ```
 
 If you built from inside `flight2/`, the binary is still emitted at the workspace `target/` when this crate is part of the workspace (default layout: `../target/release/flight-computer` relative to `flight2/`).
+
+## CLI flags
+
+The binary also accepts global flags in addition to the runtime commands above:
+
+- `--disable-file-logging` turns off on-disk vehicle-state logging.
+- `--log-dir <PATH>` writes logs to a custom directory instead of `$HOME/flight_logs`.
+- `--log-buffer-size <N>` changes the in-memory logging channel size. Default: `100`.
+- `--log-rotation-mb <N>` rotates to a new log file once the current file reaches `N` MB. Default: `100`.
+- `--print-gps` prints GPS data to the terminal at about 1 Hz.
+
+Flags can be used on their own or combined with runtime commands such as `desktop`
+or `disable-imu`.
+
+### File logging examples
+
+By default, file logging is enabled and writes to `$HOME/flight_logs`.
+
+```bash
+cargo run -p flight-computer --release
+./target/release/flight-computer
+```
+
+Write logs to a specific directory:
+
+```bash
+cargo run -p flight-computer --release -- --log-dir /home/ubuntu/flight_logs
+./target/release/flight-computer --log-dir /home/ubuntu/flight_logs
+```
+
+Rotate files at 25 MB instead of the default 100 MB:
+
+```bash
+cargo run -p flight-computer --release -- --log-rotation-mb 25
+./target/release/flight-computer --log-rotation-mb 25
+```
+
+Increase the log buffer for bursty disk I/O:
+
+```bash
+cargo run -p flight-computer --release -- --log-buffer-size 500
+./target/release/flight-computer --log-buffer-size 500
+```
+
+Disable file logging entirely:
+
+```bash
+cargo run -p flight-computer --release -- --disable-file-logging
+./target/release/flight-computer --disable-file-logging
+```
+
+Combine logging flags with runtime commands:
+
+```bash
+cargo run -p flight-computer --release -- --log-dir /home/ubuntu/flight_logs disable-imu disable-magnetometer
+./target/release/flight-computer --log-dir /home/ubuntu/flight_logs disable-imu disable-magnetometer
+```

--- a/flight2/README.md
+++ b/flight2/README.md
@@ -22,7 +22,7 @@ The flight computer accepts stackable command words to disable individual
 workers and FC-local sensors without touching their hardware interfaces:
 
 ```bash
-cargo run -p flight-computer --release -- disable-gps
+cargo run -p flight-computer --release -- disable-gps-reco
 cargo run -p flight-computer --release -- disable-imu
 cargo run -p flight-computer --release -- disable-magnetometer disable-barometer
 ```
@@ -57,7 +57,7 @@ Then run the release binary from the workspace root (artifact path is under `tar
 ```bash
 ./target/release/flight-computer
 ./target/release/flight-computer desktop
-./target/release/flight-computer disable-gps disable-imu
+./target/release/flight-computer disable-gps-reco disable-imu
 ./target/release/flight-computer disable-imu disable-magnetometer
 ```
 

--- a/flight2/src/cli.rs
+++ b/flight2/src/cli.rs
@@ -1,6 +1,9 @@
 use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 
+use crate::file_logger::LoggerConfig;
+
+/// Runtime commands for the flight computer. 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum RuntimeCommand {
   /// Run without FC-local SPI sensor workers (MAG, BAR, IMU, ADC rails)
@@ -15,6 +18,7 @@ enum RuntimeCommand {
   DisableBarometer,
 }
 
+/// State that describes which local workers should be active or not
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WorkerPlan {
   desktop_mode: bool,
@@ -25,6 +29,7 @@ pub struct WorkerPlan {
 }
 
 impl WorkerPlan {
+  /// Parses `RuntimeCommand` instance and returns the computed WorkerPlan.
   fn from_commands(commands: &[RuntimeCommand]) -> Self {
     let mut plan = Self {
       desktop_mode: false,
@@ -55,26 +60,32 @@ impl WorkerPlan {
     plan
   }
 
+  /// Returns `True` if we are in desktop mode, else 'False'
   pub fn desktop_mode(&self) -> bool {
     self.desktop_mode
   }
 
+  /// Returns `True` if we are in desktop mode, else 'False'
   pub fn gps_enabled(&self) -> bool {
     self.gps_enabled
   }
 
+  /// Returns `True` if we are collecting IMU data, else 'False'
   pub fn imu_enabled(&self) -> bool {
     self.imu_enabled
   }
 
+  /// Returns `True` if we are collecting magnetometer data, else 'False'
   pub fn magnetometer_enabled(&self) -> bool {
     self.magnetometer_enabled
   }
 
+  /// Returns `True` if we are collecting barometer data, else 'False'
   pub fn barometer_enabled(&self) -> bool {
     self.barometer_enabled
   }
 
+  /// Returns `True` if the mag / bar worker should be enabled, else 'False'
   pub fn mag_bar_enabled(&self) -> bool {
     self.magnetometer_enabled || self.barometer_enabled
   }
@@ -83,10 +94,7 @@ impl WorkerPlan {
 #[derive(Debug)]
 pub struct RuntimeConfig {
   pub worker_plan: WorkerPlan,
-  pub disable_file_logging: bool,
-  pub log_dir: Option<PathBuf>,
-  pub log_buffer_size: usize,
-  pub log_rotation_mb: u64,
+  pub logger_config: LoggerConfig,
   pub print_gps: bool,
 }
 
@@ -94,10 +102,12 @@ impl RuntimeConfig {
   fn from_args(args: Args) -> Self {
     Self {
       worker_plan: WorkerPlan::from_commands(&args.commands),
-      disable_file_logging: args.disable_file_logging,
-      log_dir: args.log_dir,
-      log_buffer_size: args.log_buffer_size,
-      log_rotation_mb: args.log_rotation_mb,
+      logger_config: LoggerConfig::from_flight_cli(
+        args.disable_file_logging,
+        args.log_dir,
+        args.log_buffer_size,
+        args.log_rotation_mb,
+      ),
       print_gps: args.print_gps,
     }
   }

--- a/flight2/src/cli.rs
+++ b/flight2/src/cli.rs
@@ -6,7 +6,7 @@ use crate::file_logger::LoggerConfig;
 /// Runtime commands for the flight computer. 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum RuntimeCommand {
-  /// Run without FC-local SPI sensor workers (MAG, BAR, IMU, ADC rails)
+  /// Disable all local sensor workers
   Desktop,
   /// Disable the GPS/RECO worker
   DisableGps,
@@ -65,22 +65,22 @@ impl WorkerPlan {
     self.desktop_mode
   }
 
-  /// Returns `True` if we are in desktop mode, else 'False'
+  /// Returns `True` if the GPS worker should be enabled, else 'False'
   pub fn gps_enabled(&self) -> bool {
     self.gps_enabled
   }
 
-  /// Returns `True` if we are collecting IMU data, else 'False'
+  /// Returns `True` if we should be collecting IMU data, else 'False'
   pub fn imu_enabled(&self) -> bool {
     self.imu_enabled
   }
 
-  /// Returns `True` if we are collecting magnetometer data, else 'False'
+  /// Returns `True` if we should be collecting magnetometer data, else 'False'
   pub fn magnetometer_enabled(&self) -> bool {
     self.magnetometer_enabled
   }
 
-  /// Returns `True` if we are collecting barometer data, else 'False'
+  /// Returns `True` if we should be collecting barometer data, else 'False'
   pub fn barometer_enabled(&self) -> bool {
     self.barometer_enabled
   }

--- a/flight2/src/cli.rs
+++ b/flight2/src/cli.rs
@@ -1,0 +1,199 @@
+use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum RuntimeCommand {
+  /// Run without FC-local SPI sensor workers (MAG, BAR, IMU, ADC rails)
+  Desktop,
+  /// Disable the GPS/RECO worker
+  DisableGps,
+  /// Disable the FC-local IMU
+  DisableImu,
+  /// Disable the FC-local magnetometer
+  DisableMagnetometer,
+  /// Disable the FC-local barometer
+  DisableBarometer,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerPlan {
+  desktop_mode: bool,
+  gps_enabled: bool,
+  imu_enabled: bool,
+  magnetometer_enabled: bool,
+  barometer_enabled: bool,
+}
+
+impl WorkerPlan {
+  fn from_commands(commands: &[RuntimeCommand]) -> Self {
+    let mut plan = Self {
+      desktop_mode: false,
+      gps_enabled: true,
+      imu_enabled: true,
+      magnetometer_enabled: true,
+      barometer_enabled: true,
+    };
+
+    for command in commands {
+      match command {
+        RuntimeCommand::Desktop => {
+          plan.desktop_mode = true;
+          plan.gps_enabled = false;
+          plan.imu_enabled = false;
+          plan.magnetometer_enabled = false;
+          plan.barometer_enabled = false;
+        }
+        RuntimeCommand::DisableGps => plan.gps_enabled = false,
+        RuntimeCommand::DisableImu => plan.imu_enabled = false,
+        RuntimeCommand::DisableMagnetometer => {
+          plan.magnetometer_enabled = false
+        }
+        RuntimeCommand::DisableBarometer => plan.barometer_enabled = false,
+      }
+    }
+
+    plan
+  }
+
+  pub fn desktop_mode(&self) -> bool {
+    self.desktop_mode
+  }
+
+  pub fn gps_enabled(&self) -> bool {
+    self.gps_enabled
+  }
+
+  pub fn imu_enabled(&self) -> bool {
+    self.imu_enabled
+  }
+
+  pub fn magnetometer_enabled(&self) -> bool {
+    self.magnetometer_enabled
+  }
+
+  pub fn barometer_enabled(&self) -> bool {
+    self.barometer_enabled
+  }
+
+  pub fn mag_bar_enabled(&self) -> bool {
+    self.magnetometer_enabled || self.barometer_enabled
+  }
+}
+
+#[derive(Debug)]
+pub struct RuntimeConfig {
+  pub worker_plan: WorkerPlan,
+  pub disable_file_logging: bool,
+  pub log_dir: Option<PathBuf>,
+  pub log_buffer_size: usize,
+  pub log_rotation_mb: u64,
+  pub print_gps: bool,
+}
+
+impl RuntimeConfig {
+  fn from_args(args: Args) -> Self {
+    Self {
+      worker_plan: WorkerPlan::from_commands(&args.commands),
+      disable_file_logging: args.disable_file_logging,
+      log_dir: args.log_dir,
+      log_buffer_size: args.log_buffer_size,
+      log_rotation_mb: args.log_rotation_mb,
+      print_gps: args.print_gps,
+    }
+  }
+}
+
+/// Command-line arguments for the flight computer.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+  /// Stackable runtime commands such as `disable-imu disable-magnetometer`
+  #[arg(value_enum, value_name = "COMMAND")]
+  commands: Vec<RuntimeCommand>,
+
+  /// Disable file logging (enabled by default)
+  #[arg(long, default_value_t = false, global = true)]
+  disable_file_logging: bool,
+
+  /// Directory for log files (default: $HOME/flight_logs)
+  #[arg(long, global = true)]
+  log_dir: Option<PathBuf>,
+
+  /// Buffer size in samples (default: 100)
+  #[arg(long, default_value_t = 100, global = true)]
+  log_buffer_size: usize,
+
+  /// File rotation size threshold in MB (default: 100)
+  #[arg(long, default_value_t = 100, global = true)]
+  log_rotation_mb: u64,
+
+  /// Print GPS data to terminal at ~1Hz (disabled by default)
+  #[arg(long, default_value_t = false, global = true)]
+  print_gps: bool,
+}
+
+pub fn parse() -> RuntimeConfig {
+  RuntimeConfig::from_args(Args::parse())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_stacked_sensor_disable_commands() {
+    let config = RuntimeConfig::from_args(Args::parse_from([
+      "flight-computer",
+      "disable-imu",
+      "disable-magnetometer",
+    ]));
+
+    assert!(!config.worker_plan.imu_enabled());
+    assert!(!config.worker_plan.magnetometer_enabled());
+    assert!(config.worker_plan.barometer_enabled());
+    assert!(!config.worker_plan.desktop_mode());
+    assert!(config.worker_plan.gps_enabled());
+    assert!(config.worker_plan.mag_bar_enabled());
+  }
+
+  #[test]
+  fn desktop_mode_disables_all_local_sensors() {
+    let config =
+      RuntimeConfig::from_args(Args::parse_from(["flight-computer", "desktop"]));
+
+    assert!(config.worker_plan.desktop_mode());
+    assert!(!config.worker_plan.gps_enabled());
+    assert!(!config.worker_plan.imu_enabled());
+    assert!(!config.worker_plan.magnetometer_enabled());
+    assert!(!config.worker_plan.barometer_enabled());
+    assert!(!config.worker_plan.mag_bar_enabled());
+  }
+
+  #[test]
+  fn disable_gps_only_turns_off_gps_worker() {
+    let config =
+      RuntimeConfig::from_args(Args::parse_from(["flight-computer", "disable-gps"]));
+
+    assert!(!config.worker_plan.desktop_mode());
+    assert!(!config.worker_plan.gps_enabled());
+    assert!(config.worker_plan.imu_enabled());
+    assert!(config.worker_plan.magnetometer_enabled());
+    assert!(config.worker_plan.barometer_enabled());
+  }
+
+  #[test]
+  fn desktop_overrides_other_runtime_commands() {
+    let config = RuntimeConfig::from_args(Args::parse_from([
+      "flight-computer",
+      "disable-gps",
+      "desktop",
+      "disable-barometer",
+    ]));
+
+    assert!(config.worker_plan.desktop_mode());
+    assert!(!config.worker_plan.gps_enabled());
+    assert!(!config.worker_plan.imu_enabled());
+    assert!(!config.worker_plan.magnetometer_enabled());
+    assert!(!config.worker_plan.barometer_enabled());
+  }
+}

--- a/flight2/src/cli.rs
+++ b/flight2/src/cli.rs
@@ -29,17 +29,22 @@ pub struct WorkerConfig {
   barometer_enabled: bool,
 }
 
-impl WorkerConfig {
-  /// Parses `SensorCommands` instance and returns the computed WorkerConfig.
-  fn from_cli_commands(commands: &[SensorCommands]) -> Self {
-    let mut plan = Self {
+impl Default for WorkerConfig {
+  fn default() -> Self {
+    Self {
       desktop_mode: false,
       gps_reco_enabled: true,
       imu_enabled: true,
       magnetometer_enabled: true,
       barometer_enabled: true,
-    };
+    }
+  }
+}
 
+impl WorkerConfig {
+  /// Parses `SensorCommands` instance and returns the computed WorkerConfig.
+  fn from_cli_commands(commands: &[SensorCommands]) -> Self {
+    let mut plan = Self::default();  
     for command in commands {
       match command {
         SensorCommands::Desktop => {

--- a/flight2/src/cli.rs
+++ b/flight2/src/cli.rs
@@ -5,7 +5,7 @@ use crate::file_logger::LoggerConfig;
 
 /// Runtime commands for the flight computer. 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum RuntimeCommand {
+enum SensorCommands {
   /// Disable all local sensor workers
   Desktop,
   /// Disable the GPS/RECO worker
@@ -19,8 +19,9 @@ enum RuntimeCommand {
 }
 
 /// State that describes which local workers should be active or not
+/// Workers are threads that are constantly collecting data from sensors
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WorkerPlan {
+pub struct WorkerConfig {
   desktop_mode: bool,
   gps_enabled: bool,
   imu_enabled: bool,
@@ -28,9 +29,9 @@ pub struct WorkerPlan {
   barometer_enabled: bool,
 }
 
-impl WorkerPlan {
-  /// Parses `RuntimeCommand` instance and returns the computed WorkerPlan.
-  fn from_commands(commands: &[RuntimeCommand]) -> Self {
+impl WorkerConfig {
+  /// Parses `SensorCommands` instance and returns the computed WorkerConfig.
+  fn from_cli_commands(commands: &[SensorCommands]) -> Self {
     let mut plan = Self {
       desktop_mode: false,
       gps_enabled: true,
@@ -41,19 +42,19 @@ impl WorkerPlan {
 
     for command in commands {
       match command {
-        RuntimeCommand::Desktop => {
+        SensorCommands::Desktop => {
           plan.desktop_mode = true;
           plan.gps_enabled = false;
           plan.imu_enabled = false;
           plan.magnetometer_enabled = false;
           plan.barometer_enabled = false;
         }
-        RuntimeCommand::DisableGps => plan.gps_enabled = false,
-        RuntimeCommand::DisableImu => plan.imu_enabled = false,
-        RuntimeCommand::DisableMagnetometer => {
+        SensorCommands::DisableGps => plan.gps_enabled = false,
+        SensorCommands::DisableImu => plan.imu_enabled = false,
+        SensorCommands::DisableMagnetometer => {
           plan.magnetometer_enabled = false
         }
-        RuntimeCommand::DisableBarometer => plan.barometer_enabled = false,
+        SensorCommands::DisableBarometer => plan.barometer_enabled = false,
       }
     }
 
@@ -93,7 +94,7 @@ impl WorkerPlan {
 
 #[derive(Debug)]
 pub struct RuntimeConfig {
-  pub worker_plan: WorkerPlan,
+  pub worker_config: WorkerConfig,
   pub logger_config: LoggerConfig,
   pub print_gps: bool,
 }
@@ -101,8 +102,8 @@ pub struct RuntimeConfig {
 impl RuntimeConfig {
   fn from_args(args: Args) -> Self {
     Self {
-      worker_plan: WorkerPlan::from_commands(&args.commands),
-      logger_config: LoggerConfig::from_flight_cli(
+      worker_config: WorkerConfig::from_cli_commands(&args.commands),
+      logger_config: LoggerConfig::from_cli_commands(
         args.disable_file_logging,
         args.log_dir,
         args.log_buffer_size,
@@ -119,7 +120,7 @@ impl RuntimeConfig {
 struct Args {
   /// Stackable runtime commands such as `disable-imu disable-magnetometer`
   #[arg(value_enum, value_name = "COMMAND")]
-  commands: Vec<RuntimeCommand>,
+  commands: Vec<SensorCommands>,
 
   /// Disable file logging (enabled by default)
   #[arg(long, default_value_t = false, global = true)]
@@ -158,12 +159,12 @@ mod tests {
       "disable-magnetometer",
     ]));
 
-    assert!(!config.worker_plan.imu_enabled());
-    assert!(!config.worker_plan.magnetometer_enabled());
-    assert!(config.worker_plan.barometer_enabled());
-    assert!(!config.worker_plan.desktop_mode());
-    assert!(config.worker_plan.gps_enabled());
-    assert!(config.worker_plan.mag_bar_enabled());
+    assert!(!config.worker_config.imu_enabled());
+    assert!(!config.worker_config.magnetometer_enabled());
+    assert!(config.worker_config.barometer_enabled());
+    assert!(!config.worker_config.desktop_mode());
+    assert!(config.worker_config.gps_enabled());
+    assert!(config.worker_config.mag_bar_enabled());
   }
 
   #[test]
@@ -171,12 +172,12 @@ mod tests {
     let config =
       RuntimeConfig::from_args(Args::parse_from(["flight-computer", "desktop"]));
 
-    assert!(config.worker_plan.desktop_mode());
-    assert!(!config.worker_plan.gps_enabled());
-    assert!(!config.worker_plan.imu_enabled());
-    assert!(!config.worker_plan.magnetometer_enabled());
-    assert!(!config.worker_plan.barometer_enabled());
-    assert!(!config.worker_plan.mag_bar_enabled());
+    assert!(config.worker_config.desktop_mode());
+    assert!(!config.worker_config.gps_enabled());
+    assert!(!config.worker_config.imu_enabled());
+    assert!(!config.worker_config.magnetometer_enabled());
+    assert!(!config.worker_config.barometer_enabled());
+    assert!(!config.worker_config.mag_bar_enabled());
   }
 
   #[test]
@@ -184,11 +185,11 @@ mod tests {
     let config =
       RuntimeConfig::from_args(Args::parse_from(["flight-computer", "disable-gps"]));
 
-    assert!(!config.worker_plan.desktop_mode());
-    assert!(!config.worker_plan.gps_enabled());
-    assert!(config.worker_plan.imu_enabled());
-    assert!(config.worker_plan.magnetometer_enabled());
-    assert!(config.worker_plan.barometer_enabled());
+    assert!(!config.worker_config.desktop_mode());
+    assert!(!config.worker_config.gps_enabled());
+    assert!(config.worker_config.imu_enabled());
+    assert!(config.worker_config.magnetometer_enabled());
+    assert!(config.worker_config.barometer_enabled());
   }
 
   #[test]
@@ -200,10 +201,10 @@ mod tests {
       "disable-barometer",
     ]));
 
-    assert!(config.worker_plan.desktop_mode());
-    assert!(!config.worker_plan.gps_enabled());
-    assert!(!config.worker_plan.imu_enabled());
-    assert!(!config.worker_plan.magnetometer_enabled());
-    assert!(!config.worker_plan.barometer_enabled());
+    assert!(config.worker_config.desktop_mode());
+    assert!(!config.worker_config.gps_enabled());
+    assert!(!config.worker_config.imu_enabled());
+    assert!(!config.worker_config.magnetometer_enabled());
+    assert!(!config.worker_config.barometer_enabled());
   }
 }

--- a/flight2/src/cli.rs
+++ b/flight2/src/cli.rs
@@ -9,7 +9,7 @@ enum SensorCommands {
   /// Disable all local sensor workers
   Desktop,
   /// Disable the GPS/RECO worker
-  DisableGps,
+  DisableGpsReco,
   /// Disable the FC-local IMU
   DisableImu,
   /// Disable the FC-local magnetometer
@@ -23,7 +23,7 @@ enum SensorCommands {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WorkerConfig {
   desktop_mode: bool,
-  gps_enabled: bool,
+  gps_reco_enabled: bool,
   imu_enabled: bool,
   magnetometer_enabled: bool,
   barometer_enabled: bool,
@@ -34,7 +34,7 @@ impl WorkerConfig {
   fn from_cli_commands(commands: &[SensorCommands]) -> Self {
     let mut plan = Self {
       desktop_mode: false,
-      gps_enabled: true,
+      gps_reco_enabled: true,
       imu_enabled: true,
       magnetometer_enabled: true,
       barometer_enabled: true,
@@ -44,12 +44,12 @@ impl WorkerConfig {
       match command {
         SensorCommands::Desktop => {
           plan.desktop_mode = true;
-          plan.gps_enabled = false;
+          plan.gps_reco_enabled = false;
           plan.imu_enabled = false;
           plan.magnetometer_enabled = false;
           plan.barometer_enabled = false;
         }
-        SensorCommands::DisableGps => plan.gps_enabled = false,
+        SensorCommands::DisableGpsReco => plan.gps_reco_enabled = false,
         SensorCommands::DisableImu => plan.imu_enabled = false,
         SensorCommands::DisableMagnetometer => {
           plan.magnetometer_enabled = false
@@ -66,9 +66,9 @@ impl WorkerConfig {
     self.desktop_mode
   }
 
-  /// Returns `True` if the GPS worker should be enabled, else 'False'
-  pub fn gps_enabled(&self) -> bool {
-    self.gps_enabled
+  /// Returns `True` if the GPS/RECO worker should be enabled, else 'False'
+  pub fn gps_reco_enabled(&self) -> bool {
+    self.gps_reco_enabled
   }
 
   /// Returns `True` if we should be collecting IMU data, else 'False'
@@ -163,7 +163,7 @@ mod tests {
     assert!(!config.worker_config.magnetometer_enabled());
     assert!(config.worker_config.barometer_enabled());
     assert!(!config.worker_config.desktop_mode());
-    assert!(config.worker_config.gps_enabled());
+    assert!(config.worker_config.gps_reco_enabled());
     assert!(config.worker_config.mag_bar_enabled());
   }
 
@@ -173,7 +173,7 @@ mod tests {
       RuntimeConfig::from_args(Args::parse_from(["flight-computer", "desktop"]));
 
     assert!(config.worker_config.desktop_mode());
-    assert!(!config.worker_config.gps_enabled());
+    assert!(!config.worker_config.gps_reco_enabled());
     assert!(!config.worker_config.imu_enabled());
     assert!(!config.worker_config.magnetometer_enabled());
     assert!(!config.worker_config.barometer_enabled());
@@ -183,10 +183,13 @@ mod tests {
   #[test]
   fn disable_gps_only_turns_off_gps_worker() {
     let config =
-      RuntimeConfig::from_args(Args::parse_from(["flight-computer", "disable-gps"]));
+      RuntimeConfig::from_args(Args::parse_from([
+        "flight-computer",
+        "disable-gps-reco",
+      ]));
 
     assert!(!config.worker_config.desktop_mode());
-    assert!(!config.worker_config.gps_enabled());
+    assert!(!config.worker_config.gps_reco_enabled());
     assert!(config.worker_config.imu_enabled());
     assert!(config.worker_config.magnetometer_enabled());
     assert!(config.worker_config.barometer_enabled());
@@ -196,13 +199,13 @@ mod tests {
   fn desktop_overrides_other_runtime_commands() {
     let config = RuntimeConfig::from_args(Args::parse_from([
       "flight-computer",
-      "disable-gps",
+      "disable-gps-reco",
       "desktop",
       "disable-barometer",
     ]));
 
     assert!(config.worker_config.desktop_mode());
-    assert!(!config.worker_config.gps_enabled());
+    assert!(!config.worker_config.gps_reco_enabled());
     assert!(!config.worker_config.imu_enabled());
     assert!(!config.worker_config.magnetometer_enabled());
     assert!(!config.worker_config.barometer_enabled());

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -444,11 +444,6 @@ impl Devices {
           self.handle_setting_abort_stage(socket, stage_name, abort_stages);
         }
 
-        SequenceDomainCommand::AbortViaStage => {
-          //println!("Sending abort message to sams");
-          self.send_sams_abort(socket, sequences);
-        }
-
         SequenceDomainCommand::RecoCommand(reco_command) => {
             self.handle_sequence_reco_message(gps_handle, reco_command);
         }

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -174,16 +174,15 @@ impl Devices {
     self.state.fc_sensors.rail_5v = sample.rail_5v;
   }
 
-  pub(crate) fn update_fc_mag_bar(
-    &mut self,
-    mag: &MagnetometerData,
-    bar: &BarometerData,
-  ) {
+  pub(crate) fn update_fc_magnetometer(&mut self, mag: &MagnetometerData) {
     self.state.fc_sensors.magnetometer = fc_sensors::Vector {
       x: mag.x as f64,
       y: mag.y as f64,
       z: mag.z as f64,
     };
+  }
+
+  pub(crate) fn update_fc_barometer(&mut self, bar: &BarometerData) {
     self.state.fc_sensors.barometer = fc_sensors::Barometer {
       temperature: bar.temperature,
       pressure: bar.pressure,

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -150,9 +150,6 @@ pub(crate) struct Devices {
   /// Whether the FC should actively monitor servo disconnects and react to
   /// them.
   monitor_servo_disconnects: bool,
-  /// Whether we are still actively communicating with servo (pulling data and
-  /// pushing telemetry).
-  servo_communication_enabled: bool,
 }
 
 impl Devices {
@@ -163,7 +160,6 @@ impl Devices {
       state: VehicleState::new(),
       last_updates: HashMap::new(),
       monitor_servo_disconnects: true,
-      servo_communication_enabled: true,
     }
   }
 
@@ -488,12 +484,6 @@ impl Devices {
         }
         SequenceDomainCommand::SetServoDisconnectMonitoring { enabled } => {
           self.monitor_servo_disconnects = enabled;
-          if enabled {
-            // When monitoring is re-enabled, also allow the FC to resume
-            // communicating with servo. The main loop will handle
-            // reconnecting on the next pull attempt if needed.
-            self.servo_communication_enabled = true;
-          }
           println!(
             "Servo disconnect monitoring {}.",
             if enabled { "enabled" } else { "disabled" }
@@ -929,16 +919,6 @@ impl Devices {
   /// Returns whether the FC should monitor servo disconnects.
   pub(crate) fn monitor_servo_disconnects(&self) -> bool {
     self.monitor_servo_disconnects
-  }
-
-  /// Returns whether the FC is currently communicating with servo.
-  pub(crate) fn servo_communication_enabled(&self) -> bool {
-    self.servo_communication_enabled
-  }
-
-  /// Sets whether the FC should communicate with servo.
-  pub(crate) fn set_servo_communication_enabled(&mut self, enabled: bool) {
-    self.servo_communication_enabled = enabled;
   }
 
   pub(crate) fn set_abort_stage(&mut self, stage: &AbortStage) {

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -487,6 +487,9 @@ impl Devices {
         // TODO: shouldn't we break out of the loop here? if we receive an abort
         // command why are we not flushing commands that come in after
         SequenceDomainCommand::Abort => should_abort = true,
+        SequenceDomainCommand::ClearAbortStatus => {
+          self.send_sams_clear_abort_status(socket);
+        }
       }
     }
 
@@ -734,6 +737,27 @@ impl Devices {
       }
     }
   }
+
+  /// Clears the abort status from all sams. This is used to tell a SAM that 
+  /// we are no longer in an abort state, which allows for future aborts to be performed.
+  pub(crate) fn send_sams_clear_abort_status(
+    &self,
+    socket: &UdpSocket,
+  ) {
+    for device in self.devices.iter() {
+      if device.get_board_id().starts_with("sam") {
+        let command = SamControlMessage::ClearAbortStatus;
+        if let Err(msg) =
+          self.serialize_and_send(socket, device.get_board_id(), &command)
+        {
+          println!("{}", msg);
+        } else {
+          println!("Cleared abort status from {}", device.get_board_id());
+        }
+      }
+    }
+  }
+
   pub(crate) fn send_sams_abort(
     &mut self,
     socket: &UdpSocket,

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -446,8 +446,7 @@ impl Devices {
 
         SequenceDomainCommand::AbortViaStage => {
           //println!("Sending abort message to sams");
-          self.send_sams_abort(socket, mappings, abort_stages, sequences, true);
-          // command from a sequence, so yes we want to use stage timers
+          self.send_sams_abort(socket, sequences);
         }
 
         SequenceDomainCommand::RecoCommand(reco_command) => {
@@ -743,10 +742,7 @@ impl Devices {
   pub(crate) fn send_sams_abort(
     &mut self,
     socket: &UdpSocket,
-    mappings: &Mappings,
-    abort_stages: &mut AbortStages,
     sequences: &mut Sequences,
-    use_stage_timers: bool,
   ) {
     // kill all sequences besides the abort stage sequence
     for (name, sequence) in &mut *sequences {
@@ -760,9 +756,7 @@ impl Devices {
     // send message to sams
     for device in self.devices.iter() {
       if device.get_board_id().starts_with("sam") {
-        let command = SamControlMessage::Abort {
-          use_stage_timers: use_stage_timers,
-        };
+        let command = SamControlMessage::Abort;
         // send message to this sam board
         if let Err(msg) =
           self.serialize_and_send(socket, device.get_board_id(), &command)

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -741,7 +741,7 @@ impl Devices {
   /// Clears the abort status from all sams. This is used to tell a SAM that 
   /// we are no longer in an abort state, which allows for future aborts to be performed.
   pub(crate) fn send_sams_clear_abort_status(
-    &self,
+    &mut self,
     socket: &UdpSocket,
   ) {
     for device in self.devices.iter() {
@@ -756,6 +756,9 @@ impl Devices {
         }
       }
     }
+
+    // clear aborted state for this abort stage
+    self.state.abort_stage.aborted = false;
   }
 
   pub(crate) fn send_sams_abort(
@@ -793,7 +796,7 @@ impl Devices {
   }
 
   // Clears any stored abort stages on sams
-  pub(crate) fn send_sam_clear_abort_stage(&self, socket: &UdpSocket) {
+  pub(crate) fn send_sam_clear_abort_stage(&mut self, socket: &UdpSocket) {
     for device in self.devices.iter() {
       if device.get_board_id().starts_with("sam") {
         let command = SamControlMessage::ClearStoredAbortStage {};

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -147,9 +147,8 @@ pub(crate) struct Devices {
   devices: Vec<Device>,
   state: VehicleState,
   last_updates: HashMap<String, Instant>,
-  /// Whether the FC should actively monitor servo disconnects and react to
-  /// them.
-  monitor_servo_disconnects: bool,
+  /// Whether the FC should abort on servo disconnect.
+  servo_disconnect_abort_enabled: bool,
 }
 
 impl Devices {
@@ -159,7 +158,7 @@ impl Devices {
       devices: Vec::new(),
       state: VehicleState::new(),
       last_updates: HashMap::new(),
-      monitor_servo_disconnects: true,
+      servo_disconnect_abort_enabled: true,
     }
   }
 
@@ -483,9 +482,9 @@ impl Devices {
           self.send_sams_toggle_camera(socket, should_enable);
         }
         SequenceDomainCommand::SetServoDisconnectMonitoring { enabled } => {
-          self.monitor_servo_disconnects = enabled;
+          self.servo_disconnect_abort_enabled = enabled;
           println!(
-            "Servo disconnect monitoring {}.",
+            "Abort on servo disconnect set to {}.",
             if enabled { "enabled" } else { "disabled" }
           );
         }
@@ -917,8 +916,8 @@ impl Devices {
   }
 
   /// Returns whether the FC should monitor servo disconnects.
-  pub(crate) fn monitor_servo_disconnects(&self) -> bool {
-    self.monitor_servo_disconnects
+  pub(crate) fn servo_disconnect_abort_enabled(&self) -> bool {
+    self.servo_disconnect_abort_enabled
   }
 
   pub(crate) fn set_abort_stage(&mut self, stage: &AbortStage) {

--- a/flight2/src/file_logger.rs
+++ b/flight2/src/file_logger.rs
@@ -49,6 +49,31 @@ impl Default for LoggerConfig {
   }
 }
 
+impl LoggerConfig {
+  /// Builds a [`LoggerConfig`] from the flight-computer CLI file-logging options
+  /// (`disable-file-logging`, `log-dir`, `log-buffer-size`, `log-rotation-mb`).
+  pub fn from_flight_cli(
+    disable_file_logging: bool,
+    log_dir: Option<PathBuf>,
+    log_buffer_size: usize,
+    log_rotation_mb: u64,
+  ) -> Self {
+    Self {
+      enabled: !disable_file_logging,
+      log_dir: log_dir.unwrap_or_else(|| {
+        std::env::var("HOME")
+          .map(PathBuf::from)
+          .unwrap_or_else(|_| PathBuf::from("."))
+          .join("flight_logs")
+      }),
+      channel_capacity: log_buffer_size,
+      batch_size: (log_buffer_size / 2).clamp(10, 100),
+      batch_timeout: Duration::from_millis(500),
+      file_size_limit: (log_rotation_mb as usize) * 1024 * 1024,
+    }
+  }
+}
+
 fn default_log_dir() -> PathBuf {
   PathBuf::from("/home/ubuntu/flight_logs")
 }

--- a/flight2/src/file_logger.rs
+++ b/flight2/src/file_logger.rs
@@ -52,7 +52,7 @@ impl Default for LoggerConfig {
 impl LoggerConfig {
   /// Builds a [`LoggerConfig`] from the flight-computer CLI file-logging options
   /// (`disable-file-logging`, `log-dir`, `log-buffer-size`, `log-rotation-mb`).
-  pub fn from_flight_cli(
+  pub fn from_cli_commands(
     disable_file_logging: bool,
     log_dir: Option<PathBuf>,
     log_buffer_size: usize,

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -437,6 +437,9 @@ fn main() -> ! {
         FlightControlMessage::CameraEnable(should_enable) => {
           devices.send_sams_toggle_camera(&socket, should_enable)
         }
+        FlightControlMessage::ClearAbortStatus => {
+          devices.send_sams_clear_abort_status(&socket);
+        }
         _ => eprintln!(
           "Received a FlightControlMessage that is not supported: {command:#?}"
         ),

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -182,21 +182,23 @@ fn main() -> ! {
     }
   };
 
-  let socket: UdpSocket = UdpSocket::bind(FC_SOCKET_ADDRESS).expect(&format!(
-    "Couldn't open port {} on IP address {}",
-    FC_SOCKET_ADDRESS.1, FC_SOCKET_ADDRESS.0
-  ));
+  let socket: UdpSocket = UdpSocket::bind(FC_SOCKET_ADDRESS)
+    .unwrap_or_else(|_| panic!("Couldn't open port {} on IP address {}",
+    FC_SOCKET_ADDRESS.1, FC_SOCKET_ADDRESS.0)
+  );
   socket
     .set_nonblocking(true)
-    .expect("Cannot set incoming to non-blocking.");
-  let radio_socket = servo::make_radio_socket()
-    .expect("Cannot create TEL radio telemetry socket.");
-  let command_socket: UnixDatagram = UnixDatagram::bind(SOCKET_PATH).expect(
-    &format!("Could not open sequence command socket on path '{SOCKET_PATH}'."),
+    .expect("Cannot set incoming to non-blocking."
   );
+  let radio_socket = servo::make_radio_socket()
+    .expect("Cannot create TEL radio telemetry socket."
+  );
+  let command_socket: UnixDatagram = UnixDatagram::bind(SOCKET_PATH)
+  .unwrap_or_else(|_| panic!("Could not open sequence command socket on path '{SOCKET_PATH}'."));
   command_socket
     .set_nonblocking(true)
-    .expect("Cannot set sequence command socket to non-blocking.");
+    .expect("Cannot set sequence command socket to non-blocking."
+  );
 
   // TODO: HAVE THIS IN A STRUCT CALLED MAIN LOOP DATA
   let mut mappings: Mappings = Vec::new();
@@ -241,7 +243,7 @@ fn main() -> ! {
     eprintln!("FC_PERF_DEBUG enabled");
   }
 
-  let mut last_received_from_servo = Instant::now(); // last time that we had an established connection with servo
+  let mut last_received_from_servo; // last time that we had an established connection with servo
   let (mut servo_stream, mut servo_address) = loop {
     match servo::establish(
       &SERVO_SOCKET_ADDRESSES,
@@ -426,10 +428,10 @@ fn main() -> ! {
       if let Some(handle) = worker_handles.gps() {
         if handle.is_running() {
           let _ = vehicle_state_sender.try_send(devices.get_state().clone());
-        } else if let Some(ref logger) = file_logger.as_ref() {
+        } else if let Some(logger) = file_logger.as_ref() {
           let _ = logger.log(devices.get_state().clone());
         }
-      } else if let Some(ref logger) = file_logger.as_ref() {
+      } else if let Some(logger) = file_logger.as_ref() {
         let _ = logger.log(devices.get_state().clone());
       }
 
@@ -598,7 +600,7 @@ fn abort(
       }
     }
 
-    sequence::execute(&mappings, sequence, sequences);
+    sequence::execute(mappings, sequence, sequences);
   } else {
     println!("Received an abort command, but no abort sequence has been set. Continuing normally...");
   }

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -219,7 +219,6 @@ fn main() -> ! {
   let mut sequences: Sequences = HashMap::new();
   let mut synchronizer: Synchronizer<WyHash, LockDisabled, 1024, 500_000> =
     Synchronizer::with_params(MMAP_PATH.as_ref());
-  let mut abort_sequence: Option<Sequence> = None;
   let mut abort_stages: AbortStages = Vec::new();
 
   // Create channel for sending vehicle state to GPS worker for logging (bounded
@@ -398,15 +397,10 @@ fn main() -> ! {
 
       match command {
         FlightControlMessage::Abort => {
-          // check which type of abort should happen, abort stage or abort seq
-          if devices.get_state().abort_stage.name != "DEFAULT" {
-            devices.send_sams_abort(
-              &socket,
-              &mut sequences,
-            );
-          } else {
-            abort(&mappings, &mut sequences, &abort_sequence);
-          }
+          devices.send_sams_abort(
+            &socket,
+            &mut sequences,
+          );
         },
         FlightControlMessage::AbortStageConfig(config) => devices.create_abort_stage(&mappings, &mut abort_stages, config),
         FlightControlMessage::SetAbortStage(stage_name) => devices.handle_setting_abort_stage(&socket, stage_name, &mut abort_stages),
@@ -431,9 +425,6 @@ fn main() -> ! {
             &mut sequences,
             &mut devices,
           );
-        }
-        FlightControlMessage::Sequence(s) if s.name == "abort" => {
-          abort_sequence = Some(s)
         }
         FlightControlMessage::Sequence(ref s) => {
           sequence::execute(&mappings, s, &mut sequences)
@@ -619,18 +610,11 @@ fn main() -> ! {
     );
 
     if should_abort {
-      // check which type of abort should happen, abort stage or abort seq
-      if devices.get_state().abort_stage.name != "DEFAULT" {
-        devices.send_sams_abort(
-          &socket,
-          &mut sequences,
-        );
-      } else {
-        abort(&mappings, &mut sequences, &abort_sequence);
-      }
+      devices.send_sams_abort(
+        &socket,
+        &mut sequences,
+      );
     }
-
-    // triggers
 
     // Optional performance diagnostics for the main loop.
     if fc_perf_debug {
@@ -642,26 +626,6 @@ fn main() -> ! {
         );
       }
     }
-  }
-}
-
-fn abort(
-  mappings: &Mappings,
-  sequences: &mut Sequences,
-  abort_sequence: &Option<Sequence>,
-) {
-  if let Some(ref sequence) = abort_sequence {
-    for (name, sequence) in &mut *sequences {
-      if name != "AbortStage" {
-        if let Err(e) = sequence.kill() {
-          println!("Couldn't kill a sequence in preperation for abort, continuing normally: {e}");
-        }
-      }
-    }
-
-    sequence::execute(&mappings, sequence, sequences);
-  } else {
-    println!("Received an abort command, but no abort sequence has been set. Continuing normally...");
   }
 }
 

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -360,17 +360,12 @@ fn main() -> ! {
     let loop_start = Instant::now();
 
     // Pull any new message from servo if we are still communicating with it.
-    let servo_message = if devices.servo_communication_enabled() {
-      get_servo_data(
-        &mut servo_stream,
-        &mut servo_address,
-        &mut last_received_from_servo,
-        &mut aborted,
-        &mut devices,
-      )
-    } else {
-      None
-    };
+    let servo_message = get_servo_data(
+      &mut servo_stream,
+      &mut servo_address,
+      &mut last_received_from_servo,
+      &mut aborted,
+    );
 
     let servo_disconnect_abort_active = devices.monitor_servo_disconnects();
 
@@ -507,9 +502,7 @@ fn main() -> ! {
     }
 
     let now = Instant::now();
-    let servo_comm_enabled = devices.servo_communication_enabled();
-    let send_umbilical = servo_comm_enabled
-      && now.duration_since(last_sent_to_servo) > FC_TO_SERVO_RATE;
+    let send_umbilical = now.duration_since(last_sent_to_servo) > FC_TO_SERVO_RATE;
     let send_radio = now.duration_since(last_sent_radio_to_servo) > FC_TO_SERVO_RADIO_RATE;
 
     if send_umbilical {
@@ -695,16 +688,7 @@ fn get_servo_data(
   servo_address: &mut SocketAddr,
   last_received_from_servo: &mut Instant,
   aborted: &mut bool,
-  devices: &mut Devices,
 ) -> Option<FlightControlMessage> {
-  // If we've been instructed to permanently stop communicating with servo after
-  // a disconnect, short-circuit immediately.
-  if !devices.servo_communication_enabled() {
-    return None;
-  }
-
-  let monitor_servo_disconnects = devices.monitor_servo_disconnects();
-
   match servo::pull(servo_stream) {
     Ok(message) => {
       *last_received_from_servo = Instant::now();
@@ -715,36 +699,26 @@ fn get_servo_data(
 
       match e {
         ServoError::ServoDisconnected => {
-          if monitor_servo_disconnects {
-            eprintln!("Attempting to reconnect to servo... ");
+          eprintln!("Attempting to reconnect to servo... ");
 
-            match servo::establish(
-              &SERVO_SOCKET_ADDRESSES,
-              Some(servo_address),
-              SERVO_RECONNECT_RETRY_COUNT,
-              SERVO_RECONNECT_TIMEOUT,
-            ) {
-              Ok(s) => {
-                (*servo_stream, *servo_address) = s;
-                *last_received_from_servo = Instant::now();
-                *aborted = false;
-                eprintln!("Connection successfully re-established.");
-              }
-              Err(e) => {
-                eprintln!(
-                  "Connection could not be re-established: {e}. Continuing..."
-                );
-              }
-            };
-          } else {
-            eprintln!(
-              "Servo disconnected, but monitoring is disabled; ceasing further communication with servo."
-            );
-            // Once we've seen a disconnect with monitoring disabled, stop all
-            // future attempts to reconnect to, pull from, or push
-            // telemetry to servo.
-            devices.set_servo_communication_enabled(false);
-          }
+          match servo::establish(
+            &SERVO_SOCKET_ADDRESSES,
+            Some(servo_address),
+            SERVO_RECONNECT_RETRY_COUNT,
+            SERVO_RECONNECT_TIMEOUT,
+          ) {
+            Ok(s) => {
+              (*servo_stream, *servo_address) = s;
+              *last_received_from_servo = Instant::now();
+              *aborted = false;
+              eprintln!("Connection successfully re-established.");
+            }
+            Err(e) => {
+              eprintln!(
+                "Connection could not be re-established: {e}. Continuing..."
+              );
+            }
+          };
         }
         ServoError::DeserializationFailed(_) => {}
         ServoError::TransportFailed(_) => {}

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -388,10 +388,7 @@ fn main() -> ! {
       // abort after SERVO_TO_FC_TIME_TO_LIVE seconds.
       devices.send_sams_abort(
         &socket,
-        &mappings,
-        &mut abort_stages,
         &mut sequences,
-        true,
       );
     }
 
@@ -405,11 +402,8 @@ fn main() -> ! {
           if devices.get_state().abort_stage.name != "DEFAULT" {
             devices.send_sams_abort(
               &socket,
-              &mappings,
-              &mut abort_stages,
               &mut sequences,
-              true,
-            ); // abort message means we use stage timers
+            );
           } else {
             abort(&mappings, &mut sequences, &abort_sequence);
           }
@@ -629,11 +623,8 @@ fn main() -> ! {
       if devices.get_state().abort_stage.name != "DEFAULT" {
         devices.send_sams_abort(
           &socket,
-          &mappings,
-          &mut abort_stages,
           &mut sequences,
-          true,
-        ); // not servo LOC, abort with stage timers
+        );
       } else {
         abort(&mappings, &mut sequences, &abort_sequence);
       }

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -1,3 +1,4 @@
+mod cli;
 mod common_so;
 mod device;
 mod file_logger;
@@ -9,17 +10,18 @@ mod servo;
 mod state;
 
 use crate::{
+  cli::{parse as parse_cli, RuntimeConfig, WorkerPlan},
   common_so::{materialize_common_so, python_path_for},
   device::{AbortStages, Mappings, Devices},
-  file_logger::{FileLogger, LoggerConfig},
-  sensors::spawn_imu_adc_worker,
+  file_logger::{FileLogger, LoggerConfig, TimestampedVehicleState},
+  gps::GpsHandle,
+  sensors::{spawn_imu_adc_worker, ImuAdcSample, MagBarSample, SensorHandle},
   sequence::Sequences,
   servo::ServoError,
   state::Ingestible,
 };
-use clap::{Parser, Subcommand};
 use common::{
-  comm::{bms, AbortStage, FlightControlMessage, Sequence},
+  comm::{bms, AbortStage, FlightControlMessage, Sequence, VehicleState},
   sequence::{MMAP_PATH, SOCKET_PATH},
 };
 use mmap_sync::{locks::LockDisabled, synchronizer::Synchronizer};
@@ -100,47 +102,30 @@ const GOLDFISH_SYSTEM_SAFE_TIMER: Duration = Duration::from_secs(60 * 25); // 25
 /// timer. Ground computer configuration should not be affected.
 const UMBILICAL_BUS_VOLTAGE_THRESHOLD: f64 = 10.0; // 10 V
 
-#[derive(Subcommand, Debug, Clone, Copy)]
-enum Commands {
-  /// Run without FC-local SPI sensor workers (MAG+BAR, IMU+ADC)
-  Desktop,
+/// Handles for the runtime workers.
+struct WorkerHandles {
+  gps_handle: Option<GpsHandle>,
+  mag_bar_handle: Option<SensorHandle<MagBarSample>>,
+  imu_adc_handle: Option<SensorHandle<ImuAdcSample>>,
 }
 
-/// Command-line arguments for the flight computer
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
-struct Args {
-  #[command(subcommand)]
-  command: Option<Commands>,
+impl WorkerHandles {
+  fn gps(&self) -> Option<&GpsHandle> {
+    self.gps_handle.as_ref()
+  }
 
-  /// Disable file logging (enabled by default)
-  #[arg(long, default_value_t = false, global = true)]
-  disable_file_logging: bool,
+  fn mag_bar(&self) -> Option<&SensorHandle<MagBarSample>> {
+    self.mag_bar_handle.as_ref()
+  }
 
-  /// Directory for log files (default: $HOME/flight_logs)
-  #[arg(long, global = true)]
-  log_dir: Option<PathBuf>,
-
-  /// Buffer size in samples (default: 100)
-  #[arg(long, default_value_t = 100, global = true)]
-  log_buffer_size: usize,
-
-  /// File rotation size threshold in MB (default: 100)
-  #[arg(long, default_value_t = 100, global = true)]
-  log_rotation_mb: u64,
-
-  /// Print GPS data to terminal at ~1Hz (disabled by default)
-  #[arg(long, default_value_t = false, global = true)]
-  print_gps: bool,
-
-  /// Disable GPS and RECO worker initialization entirely.
-  #[arg(long, default_value_t = false, global = true)]
-  disable_gps: bool,
+  fn imu_adc(&self) -> Option<&SensorHandle<ImuAdcSample>> {
+    self.imu_adc_handle.as_ref()
+  }
 }
 
 fn main() -> ! {
-  // Parse command-line arguments
-  let args = Args::parse();
+  // Parse the runtime configuration from the command line arguments
+  let runtime_config: RuntimeConfig = parse_cli();
 
   // Materialize the built libcommon.so file to a temporary directory on disk
   let common_so_dir =
@@ -166,24 +151,24 @@ fn main() -> ! {
 
   // Initialize file logger
   let file_logger_config = LoggerConfig {
-    enabled: !args.disable_file_logging,
-    log_dir: args.log_dir.unwrap_or_else(|| {
+    enabled: !runtime_config.disable_file_logging,
+    log_dir: runtime_config.log_dir.unwrap_or_else(|| {
       env::var("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("."))
         .join("flight_logs")
     }),
-    channel_capacity: args.log_buffer_size,
+    channel_capacity: runtime_config.log_buffer_size,
     // Half of buffer, but at least 10 and at most 100.
-    batch_size: (args.log_buffer_size / 2).max(10).min(100),
+    batch_size: (runtime_config.log_buffer_size / 2).clamp(10, 100),
     batch_timeout: Duration::from_millis(500),
     // Convert MB to bytes.
-    file_size_limit: (args.log_rotation_mb as usize) * 1024 * 1024,
+    file_size_limit: (runtime_config.log_rotation_mb as usize) * 1024 * 1024,
   };
 
   let file_logger = match FileLogger::new(file_logger_config.clone()) {
     Ok(logger) => {
-      if !args.disable_file_logging {
+      if !runtime_config.disable_file_logging {
         println!(
           "File logging enabled. Log directory: {:?}",
           file_logger_config.log_dir
@@ -230,73 +215,13 @@ fn main() -> ! {
   let file_logger_sender =
     file_logger.as_ref().map(|logger| logger.clone_sender());
 
-  // Spawn GPS worker thread. If initialization fails, continue without GPS/RECO.
-  let gps_handle = if args.disable_gps {
-    println!("GPS/RECO worker disabled by command-line flag.");
-    None
-  } else {
-    match gps::GpsManager::spawn(
-      1,
-      None,
-      vehicle_state_receiver,
-      file_logger_sender,
-      args.print_gps,
-    ) {
-      Ok(handle) => {
-        println!("GPS worker started successfully on I2C bus 1.");
-        if args.print_gps {
-          println!("GPS data printing enabled (rate: ~1Hz)");
-        }
-        Some(handle)
-      }
-      Err(e) => {
-        eprintln!(
-          "Failed to start GPS/RECO worker: {e}. Continuing without GPS/RECO."
-        );
-        None
-      }
-    }
-  };
-
-  // Spawn FC-local SPI sensor workers unless `desktop` subcommand is used.
-  let (mag_bar_handle, imu_adc_handle) = if matches!(
-    args.command,
-    Some(Commands::Desktop)
-  ) {
-    println!(
-      "Desktop mode enabled. Skipping MAG+BAR and IMU+ADC worker startup."
-    );
-    (None, None)
-  } else {
-    let mag_bar_handle = match sensors::spawn_mag_bar_worker() {
-      Ok(handle) => {
-        println!("MAG+BAR worker started successfully on SPI0.");
-        Some(handle)
-      }
-
-      Err(e) => {
-        eprintln!(
-          "Failed to start MAG/BAR worker: {e}. Continuing without MAG/BAR."
-        );
-        None
-      }
-    };
-
-    let imu_adc_handle = match spawn_imu_adc_worker() {
-      Ok(handle) => {
-        println!("IMU+ADC worker started successfully on SPI5.");
-        Some(handle)
-      }
-      Err(e) => {
-        eprintln!(
-          "Failed to start IMU/ADC worker: {e}. Continuing without FC IMU/rails."
-        );
-        None
-      }
-    };
-
-    (mag_bar_handle, imu_adc_handle)
-  };
+  // Start the runtime workers based on the runtime configuration
+  let worker_handles: WorkerHandles = start_runtime_workers(
+    runtime_config.worker_plan,
+    vehicle_state_receiver,
+    file_logger_sender,
+    runtime_config.print_gps,
+  );
 
   println!(
     "Flight Computer running on version {}\n",
@@ -418,7 +343,7 @@ fn main() -> ! {
         FlightControlMessage::SetAbortStage(stage_name) => devices.handle_setting_abort_stage(&socket, stage_name, &mut abort_stages),
         FlightControlMessage::BmsCommand(c) => devices.send_bms_command(&socket, c),
         FlightControlMessage::RecoCommand(reco_command) => {
-          devices.handle_gui_reco_command(gps_handle.as_ref(), reco_command);
+          devices.handle_gui_reco_command(worker_handles.gps(), reco_command);
         }
         FlightControlMessage::Trigger(_) => todo!(),
         FlightControlMessage::Mappings(m) => {
@@ -463,7 +388,7 @@ fn main() -> ! {
 
     // Ingest any newly available GPS and RECO samples without blocking the
     // control loop.
-    if let Some(handle) = gps_handle.as_ref() {
+    if let Some(handle) = worker_handles.gps() {
       if let Some(gps_reco_sample) = handle.try_get_sample() {
         if let Some(gps) = gps_reco_sample.gps {
           devices.update_gps(gps);
@@ -474,16 +399,21 @@ fn main() -> ! {
     }
 
     // Ingest any newly available IMU/ADC samples from the worker
-    if let Some(handle) = imu_adc_handle.as_ref() {
+    if let Some(handle) = worker_handles.imu_adc() {
       while let Ok(sample) = handle.try_read() {
         devices.update_fc_imu_adc(&sample);
       }
     }
 
-    // Ingest any newly available MAG and BAR samples
-    if let Some(handle) = &mag_bar_handle {
-      while let Ok((mag_data, bar_data)) = handle.try_read() {
-        devices.update_fc_mag_bar(&mag_data, &bar_data);
+    // Ingest any newly available MAG/BAR samples from the shared worker
+    if let Some(handle) = worker_handles.mag_bar() {
+      while let Ok(sample) = handle.try_read() {
+        if let Some(mag_data) = sample.magnetometer.as_ref() {
+          devices.update_fc_magnetometer(mag_data);
+        }
+        if let Some(bar_data) = sample.barometer.as_ref() {
+          devices.update_fc_barometer(bar_data);
+        }
       }
     }
 
@@ -493,7 +423,7 @@ fn main() -> ! {
     // FileLogger.
     let now = Instant::now();
     if now.duration_since(last_sent_to_gps_worker) >= LOG_INTERVAL {
-      if let Some(handle) = gps_handle.as_ref() {
+      if let Some(handle) = worker_handles.gps() {
         if handle.is_running() {
           let _ = vehicle_state_sender.try_send(devices.get_state().clone());
         } else if let Some(ref logger) = file_logger.as_ref() {
@@ -621,7 +551,7 @@ fn main() -> ! {
       sam_commands,
       &mut abort_stages,
       &mut sequences,
-      gps_handle.as_ref(),
+      worker_handles.gps(),
     );
 
     if should_abort {
@@ -867,6 +797,148 @@ while True:
     script: abort_stage_body.to_string(),
   };
   sequence::execute(mappings, &abort_stage_seq, sequences);
+}
+
+/// Starts the GPS/RECO worker.
+fn start_gps_worker(
+  plan: WorkerPlan,
+  vehicle_state_receiver: mpsc::Receiver<VehicleState>,
+  file_logger_sender: Option<mpsc::SyncSender<TimestampedVehicleState>>,
+  print_gps: bool,
+) -> Option<GpsHandle> {
+  if !plan.gps_enabled() {
+    println!("GPS/RECO worker disabled by runtime configuration.");
+    return None;
+  }
+
+  match gps::GpsManager::spawn(
+    1,
+    None,
+    vehicle_state_receiver,
+    file_logger_sender,
+    print_gps,
+  ) {
+    Ok(handle) => {
+      println!("GPS worker started successfully on I2C bus 1.");
+      if print_gps {
+        println!("GPS data printing enabled (rate: ~1Hz)");
+      }
+      Some(handle)
+    }
+    Err(e) => {
+      eprintln!(
+        "Failed to start GPS/RECO worker: {e}. Continuing without GPS/RECO."
+      );
+      None
+    }
+  }
+}
+
+/// Starts the MAG/BAR worker.
+fn start_mag_bar_worker(
+  plan: WorkerPlan,
+) -> Option<SensorHandle<MagBarSample>> {
+  if !plan.mag_bar_enabled() {
+    println!("MAG/BAR worker disabled by runtime configuration.");
+    return None;
+  }
+
+  if !plan.magnetometer_enabled() {
+    println!("Magnetometer disabled by runtime configuration.");
+  }
+
+  if !plan.barometer_enabled() {
+    println!("Barometer disabled by runtime configuration.");
+  }
+
+  match sensors::spawn_mag_bar_worker(
+    plan.magnetometer_enabled(),
+    plan.barometer_enabled(),
+  ) {
+    Ok(handle) => {
+      match (plan.magnetometer_enabled(), plan.barometer_enabled()) {
+        (true, true) => {
+          println!("MAG+BAR worker started successfully on SPI0.");
+        }
+        (false, true) => {
+          println!("BAR-only worker started successfully on SPI0.");
+        }
+        (true, false) => {
+          println!("MAG-only worker started successfully on SPI0.");
+        }
+        (false, false) => unreachable!(),
+      }
+      Some(handle)
+    }
+    Err(e) => {
+      eprintln!(
+        "Failed to start MAG/BAR worker: {e}. Continuing without enabled MAG/BAR sensors."
+      );
+      None
+    }
+  }
+}
+
+/// Starts the IMU/ADC worker.
+fn start_imu_adc_worker(
+  plan: WorkerPlan,
+) -> Option<SensorHandle<ImuAdcSample>> {
+  if !plan.imu_enabled() {
+    println!("IMU disabled by runtime configuration. Starting ADC-only worker.");
+  }
+
+  match spawn_imu_adc_worker(plan.imu_enabled()) {
+    Ok(handle) => {
+      if plan.imu_enabled() {
+        println!("IMU+ADC worker started successfully on SPI5.");
+      } else {
+        println!("ADC-only worker started successfully on SPI5.");
+      }
+      Some(handle)
+    }
+    Err(e) => {
+      if plan.imu_enabled() {
+        eprintln!(
+          "Failed to start IMU/ADC worker: {e}. Continuing without FC IMU/rails."
+        );
+      } else {
+        eprintln!(
+          "Failed to start ADC-only worker: {e}. Continuing without FC rail measurements."
+        );
+      }
+      None
+    }
+  }
+}
+
+/// Starts all FC-local runtime workers from the computed worker plan.
+fn start_runtime_workers(
+  plan: WorkerPlan,
+  vehicle_state_receiver: mpsc::Receiver<VehicleState>,
+  file_logger_sender: Option<mpsc::SyncSender<TimestampedVehicleState>>,
+  print_gps: bool,
+) -> WorkerHandles {
+  if plan.desktop_mode() {
+    println!(
+      "Desktop mode enabled. Skipping GPS/RECO, magnetometer, barometer, IMU, and ADC worker startup."
+    );
+    return WorkerHandles {
+      gps_handle: None,
+      mag_bar_handle: None,
+      imu_adc_handle: None,
+    };
+  }
+
+  WorkerHandles {
+    gps_handle: start_gps_worker(
+      plan,
+      vehicle_state_receiver,
+      file_logger_sender,
+      print_gps,
+    ),
+    mag_bar_handle: start_mag_bar_worker(plan),
+    imu_adc_handle: start_imu_adc_worker(plan),
+  }
 }
 
 /// Checks if python3 and the passed python modules exist.

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -150,7 +150,6 @@ fn main() -> ! {
 
   // Initialize file logger
   let file_logger_config = runtime_config.logger_config.clone();
-
   let file_logger = match FileLogger::new(file_logger_config.clone()) {
     Ok(logger) => {
       if file_logger_config.enabled {

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -843,7 +843,7 @@ fn start_abort_stage_process(
 import time
 while True:
     try:
-        if curr_abort_stage() != "FLIGHT" and aborted_in_this_stage() == False and eval(curr_abort_condition()) == True:
+        if aborted_in_this_stage() == False and eval(curr_abort_condition()) == True:
             #print("ABORTING")
             abort()
     except Exception as e:

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -13,7 +13,7 @@ use crate::{
   cli::{parse as parse_cli, RuntimeConfig, WorkerPlan},
   common_so::{materialize_common_so, python_path_for},
   device::{AbortStages, Mappings, Devices},
-  file_logger::{FileLogger, LoggerConfig, TimestampedVehicleState},
+  file_logger::{FileLogger, TimestampedVehicleState},
   gps::GpsHandle,
   sensors::{spawn_imu_adc_worker, ImuAdcSample, MagBarSample, SensorHandle},
   sequence::Sequences,
@@ -31,7 +31,6 @@ use std::{
   ffi::OsStr,
   net::{SocketAddr, TcpStream, UdpSocket},
   os::unix::net::UnixDatagram,
-  path::PathBuf,
   process::Command,
   sync::mpsc,
   thread,
@@ -150,25 +149,11 @@ fn main() -> ! {
   }
 
   // Initialize file logger
-  let file_logger_config = LoggerConfig {
-    enabled: !runtime_config.disable_file_logging,
-    log_dir: runtime_config.log_dir.unwrap_or_else(|| {
-      env::var("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("."))
-        .join("flight_logs")
-    }),
-    channel_capacity: runtime_config.log_buffer_size,
-    // Half of buffer, but at least 10 and at most 100.
-    batch_size: (runtime_config.log_buffer_size / 2).clamp(10, 100),
-    batch_timeout: Duration::from_millis(500),
-    // Convert MB to bytes.
-    file_size_limit: (runtime_config.log_rotation_mb as usize) * 1024 * 1024,
-  };
+  let file_logger_config = runtime_config.logger_config.clone();
 
   let file_logger = match FileLogger::new(file_logger_config.clone()) {
     Ok(logger) => {
-      if !runtime_config.disable_file_logging {
+      if file_logger_config.enabled {
         println!(
           "File logging enabled. Log directory: {:?}",
           file_logger_config.log_dir

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -792,7 +792,7 @@ fn start_gps_worker(
   file_logger_sender: Option<mpsc::SyncSender<TimestampedVehicleState>>,
   print_gps: bool,
 ) -> Option<GpsHandle> {
-  if !plan.gps_enabled() {
+  if !plan.gps_reco_enabled() {
     println!("GPS/RECO worker disabled by runtime configuration.");
     return None;
   }

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -226,20 +226,18 @@ fn main() -> ! {
     eprintln!("FC_PERF_DEBUG enabled");
   }
 
-  let mut last_received_from_servo; // last time that we had an established connection with servo
-  let (mut servo_stream, mut servo_address) = loop {
+  let (mut servo_stream, mut servo_address, mut last_received_from_servo) = loop {
     match servo::establish(
       &SERVO_SOCKET_ADDRESSES,
       None,
       3,
       Duration::from_secs(2),
     ) {
-      Ok(s) => {
+      Ok((stream, address)) => {
         println!(
           "Connected to servo successfully. Beginning control cycle...\n"
         );
-        last_received_from_servo = Instant::now();
-        break s;
+        break (stream, address, Instant::now());
       }
       Err(e) => {
         println!("Couldn't connect due to error: {e}\n");

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -10,7 +10,7 @@ mod servo;
 mod state;
 
 use crate::{
-  cli::{parse as parse_cli, RuntimeConfig, WorkerPlan},
+  cli::{parse as parse_cli, RuntimeConfig, WorkerConfig},
   common_so::{materialize_common_so, python_path_for},
   device::{AbortStages, Mappings, Devices},
   file_logger::{FileLogger, TimestampedVehicleState},
@@ -203,7 +203,7 @@ fn main() -> ! {
 
   // Start the runtime workers based on the runtime configuration
   let worker_handles: WorkerHandles = start_runtime_workers(
-    runtime_config.worker_plan,
+    runtime_config.worker_config,
     vehicle_state_receiver,
     file_logger_sender,
     runtime_config.print_gps,
@@ -787,7 +787,7 @@ while True:
 
 /// Starts the GPS/RECO worker.
 fn start_gps_worker(
-  plan: WorkerPlan,
+  plan: WorkerConfig,
   vehicle_state_receiver: mpsc::Receiver<VehicleState>,
   file_logger_sender: Option<mpsc::SyncSender<TimestampedVehicleState>>,
   print_gps: bool,
@@ -822,7 +822,7 @@ fn start_gps_worker(
 
 /// Starts the MAG/BAR worker.
 fn start_mag_bar_worker(
-  plan: WorkerPlan,
+  plan: WorkerConfig,
 ) -> Option<SensorHandle<MagBarSample>> {
   if !plan.mag_bar_enabled() {
     println!("MAG/BAR worker disabled by runtime configuration.");
@@ -867,7 +867,7 @@ fn start_mag_bar_worker(
 
 /// Starts the IMU/ADC worker.
 fn start_imu_adc_worker(
-  plan: WorkerPlan,
+  plan: WorkerConfig,
 ) -> Option<SensorHandle<ImuAdcSample>> {
   if !plan.imu_enabled() {
     println!("IMU disabled by runtime configuration. Starting ADC-only worker.");
@@ -899,7 +899,7 @@ fn start_imu_adc_worker(
 
 /// Starts all FC-local runtime workers from the computed worker plan.
 fn start_runtime_workers(
-  plan: WorkerPlan,
+  plan: WorkerConfig,
   vehicle_state_receiver: mpsc::Receiver<VehicleState>,
   file_logger_sender: Option<mpsc::SyncSender<TimestampedVehicleState>>,
   print_gps: bool,

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -367,10 +367,8 @@ fn main() -> ! {
       &mut aborted,
     );
 
-    let servo_disconnect_abort_active = devices.monitor_servo_disconnects();
-
     if !aborted
-      && servo_disconnect_abort_active
+      && devices.servo_disconnect_abort_enabled()
       && (Instant::now().duration_since(last_received_from_servo)
         > SERVO_TO_FC_TIME_TO_LIVE)
     {

--- a/flight2/src/sensors.rs
+++ b/flight2/src/sensors.rs
@@ -105,6 +105,11 @@ pub struct BarometerData {
   pub temperature: f64,
 }
 
+pub struct MagBarSample {
+  pub magnetometer: Option<MagnetometerData>,
+  pub barometer: Option<BarometerData>,
+}
+
 #[derive(Debug)]
 pub enum MagBarError {
   Magnetometer(lis2mdl::Error),
@@ -139,46 +144,68 @@ impl From<ms5611::Error> for MagBarError {
 }
 
 pub fn spawn_mag_bar_worker(
-) -> Result<SensorHandle<(MagnetometerData, BarometerData)>, MagBarError> {
+  enable_magnetometer: bool,
+  enable_barometer: bool,
+) -> Result<SensorHandle<MagBarSample>, MagBarError> {
   let controller = gpio_controller();
 
-  let mut magnetometer = LIS2MDL::new_with_gpio_pin(
-    "/dev/spidev0.1",
-    Some(Box::new(controller.get_pin(7))),
-  )?;
-  let mut barometer = MS5611::new_with_gpio_pin(
-    "/dev/spidev0.0",
-    Some(Box::new(controller.get_pin(8))),
-    4096,
-  )?;
+  let mut magnetometer = if enable_magnetometer {
+    Some(LIS2MDL::new_with_gpio_pin(
+      "/dev/spidev0.1",
+      Some(Box::new(controller.get_pin(7))),
+    )?)
+  } else {
+    None
+  };
+  let mut barometer = if enable_barometer {
+    Some(MS5611::new_with_gpio_pin(
+      "/dev/spidev0.0",
+      Some(Box::new(controller.get_pin(8))),
+      4096,
+    )?)
+  } else {
+    None
+  };
 
   Ok(SensorHandle::new(move |tx| {
-    match (
-      magnetometer.read(),
-      barometer.read_pressure(),
-      barometer.read_temperature(),
-    ) {
-      (Ok(magnetometer_data), Ok(pressure), Ok(temperature)) => {
-        if tx
-          .send((
-            magnetometer_data,
-            BarometerData {
-              pressure,
-              temperature,
-            },
-          ))
-          .is_err()
-        {
-          eprintln!("Cannot send mag/bar sensor data to closed channel");
+    let magnetometer_data = if let Some(magnetometer) = magnetometer.as_mut() {
+      match magnetometer.read() {
+        Ok(data) => Some(data),
+        Err(error) => {
+          eprintln!("Failed to read magnetometer sensor data: {error:?}");
+          None
         }
       }
-      (mag, pressure, temp) => {
-        eprintln!("Failed to read mag/bar sensor data:");
-        eprintln!("- Magnetometer: {mag:?}");
-        eprintln!("- Barometer pressure: {pressure:?}");
-        eprintln!("- Barometer temperature: {temp:?}");
-      }
+    } else {
+      None
     };
+
+    let barometer_data = if let Some(barometer) = barometer.as_mut() {
+      match (barometer.read_pressure(), barometer.read_temperature()) {
+        (Ok(pressure), Ok(temperature)) => Some(BarometerData {
+          pressure,
+          temperature,
+        }),
+        (pressure, temp) => {
+          eprintln!("Failed to read barometer sensor data:");
+          eprintln!("- Barometer pressure: {pressure:?}");
+          eprintln!("- Barometer temperature: {temp:?}");
+          None
+        }
+      }
+    } else {
+      None
+    };
+
+    if tx
+      .send(MagBarSample {
+        magnetometer: magnetometer_data,
+        barometer: barometer_data,
+      })
+      .is_err()
+    {
+      eprintln!("Cannot send mag/bar sensor data to closed channel");
+    }
   }))
 }
 
@@ -496,11 +523,16 @@ fn read_imu_sample(
 /// Spawns a worker thread that samples the IMU and ADC and sends the samples to
 /// a channel.
 pub fn spawn_imu_adc_worker(
+  enable_imu: bool,
 ) -> Result<SensorHandle<ImuAdcSample>, ImuAdcWorkerError> {
-  let mut imu = init_imu().map_err(|e| {
-    eprintln!("IMU initialization failed: {e}");
-    e
-  })?;
+  let mut imu = if enable_imu {
+    Some(init_imu().map_err(|e| {
+      eprintln!("IMU initialization failed: {e}");
+      e
+    })?)
+  } else {
+    None
+  };
 
   let mut adc = init_adc().map_err(|e| {
     eprintln!("ADC initialization failed: {e:?}");
@@ -517,9 +549,9 @@ pub fn spawn_imu_adc_worker(
       Ok(logger) => Some(Arc::new(logger)),
       Err(e) => {
         eprintln!(
-        "Failed to initialize IMU file logger (continuing without logging): {}",
-        e
-      );
+          "Failed to initialize IMU file logger (continuing without logging): {}",
+          e
+        );
         None
       }
     };
@@ -531,37 +563,39 @@ pub fn spawn_imu_adc_worker(
 
   Ok(SensorHandle::new(move |tx: &Sender<ImuAdcSample>| {
     // Sample IMU
-    if let Some(new_imu) = read_imu_sample(&mut imu, &mut last_data_counter) {
-      current_imu_sample = new_imu;
+    if let Some(imu) = imu.as_mut() {
+      if let Some(new_imu) = read_imu_sample(imu, &mut last_data_counter) {
+        current_imu_sample = new_imu;
 
-      // Log IMU sample to disk if logger is available
-      if let Some(ref imu_logger) = imu_logger_for_thread {
-        match imu_logger.log(current_imu_sample) {
-          Err(ImuLoggerError::ChannelFull) => {
-            // Channel full is expected under heavy load - rate-limit warning.
-            static mut LAST_WARN: Option<Instant> = None;
-            unsafe {
-              let now = Instant::now();
-              let should_warn = LAST_WARN
-                .map(|last| now.duration_since(last).as_secs() >= 5)
-                .unwrap_or(true);
-              if should_warn {
-                eprintln!(
-                  "IMU logging channel full (disk I/O cannot keep up). Some data may be dropped."
-                );
-                LAST_WARN = Some(now);
+        // Log IMU sample to disk if logger is available
+        if let Some(ref imu_logger) = imu_logger_for_thread {
+          match imu_logger.log(current_imu_sample) {
+            Err(ImuLoggerError::ChannelFull) => {
+              // Channel full is expected under heavy load - rate-limit warning.
+              static mut LAST_WARN: Option<Instant> = None;
+              unsafe {
+                let now = Instant::now();
+                let should_warn = LAST_WARN
+                  .map(|last| now.duration_since(last).as_secs() >= 5)
+                  .unwrap_or(true);
+                if should_warn {
+                  eprintln!(
+                    "IMU logging channel full (disk I/O cannot keep up). Some data may be dropped."
+                  );
+                  LAST_WARN = Some(now);
+                }
               }
             }
+            Err(ImuLoggerError::ChannelDisconnected) => {
+              // Writer thread died – this is fatal.
+              panic!("IMU logging channel disconnected (writer thread may have crashed)");
+            }
+            Err(e) => {
+              // Other errors (IO, serialization) – treat as fatal for now.
+              panic!("Failed to log IMU data to disk: {e}");
+            }
+            Ok(()) => {}
           }
-          Err(ImuLoggerError::ChannelDisconnected) => {
-            // Writer thread died – this is fatal.
-            panic!("IMU logging channel disconnected (writer thread may have crashed)");
-          }
-          Err(e) => {
-            // Other errors (IO, serialization) – treat as fatal for now.
-            panic!("Failed to log IMU data to disk: {e}");
-          }
-          Ok(()) => {}
         }
       }
     }

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -38,6 +38,7 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
       abort_info.received_abort = false;
       abort_info.all_valves_aborted = false;
       abort_info.time_aborted = None;
+      clear_abort_stage_valve_states(abort_valve_states);
     },
     SamControlMessage::ClearStoredAbortStage {  } => {
       *abort_valve_states = Vec::<(ValveAction, bool)>::new();
@@ -51,6 +52,14 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
     SamControlMessage::LaunchLugDetonate(should_enable) => {
       toggle_launch_lug_detonate(should_enable);
     },
+  }
+}
+
+/// Clears the abort stage valve states by setting all aborted flags for valves 
+/// to false.
+fn clear_abort_stage_valve_states(abort_valve_states: &mut Vec<(ValveAction, bool)>) {
+  for (_, aborted) in abort_valve_states {
+    *aborted = false;
   }
 }
 

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -29,10 +29,15 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
         &mut abort_info.received_abort,
       );
     },
-    SamControlMessage::Abort {} => {
+    SamControlMessage::Abort => {
       abort_info.time_aborted = Some(Instant::now()); // do this before so timer instantly starts, also to prevent reading stale timer
       safe_valves(abort_valve_states, &abort_info.time_aborted, &mut abort_info.all_valves_aborted);
       abort_info.received_abort = true; 
+    },
+    SamControlMessage::ClearAbortStatus => {
+      abort_info.received_abort = false;
+      abort_info.all_valves_aborted = false;
+      abort_info.time_aborted = None;
     },
     SamControlMessage::ClearStoredAbortStage {  } => {
       *abort_valve_states = Vec::<(ValveAction, bool)>::new();

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -66,31 +66,35 @@ pub fn check_valve_abort_timers(abort_valve_states: &mut Vec<(ValveAction, bool)
 // safe the valves by going to safe states (if abort stage is set) or depowering valves
 pub fn safe_valves(abort_valve_states: &mut Vec<(ValveAction, bool)>, time_aborted: &Option<Instant>, all_valves_aborted: &mut bool) {
   let mut non_aborted_valve_exists = false;
-  // check if an abort stage has been set (indirectly) by seeing if we have predefined abort valve states
+
+  // if we have not aborted all valves, valves still need to be safed
   if !*all_valves_aborted {
-    for (valve_info, aborted) in abort_valve_states {
+    // check if an abort stage has been set by seeing if we have any predefined abort valve states
+    if !abort_valve_states.is_empty() {
+      for (valve_info, aborted) in abort_valve_states {
 
-      // abort the valve if we want an instant abort OR if our timer is up and we haven't aborted yet
-      if !*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer  {
-        actuate_valve(valve_info.channel_num, valve_info.powered);
+        // abort the valve if we want an instant abort OR if our timer is up and we haven't aborted yet
+        if !*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer  {
+          actuate_valve(valve_info.channel_num, valve_info.powered);
 
-        // mark this valve as aborted 
-        *aborted = true;
+          // mark this valve as aborted 
+          *aborted = true;
+        }
+
+        if !*aborted {
+          non_aborted_valve_exists = true;
+        } 
       }
+    } else { 
+      // we can assume that no abort stage has been set, therefore we just depower all valves
+      for i in 1..7 {
+        actuate_valve(i, false);
+      }
+    }
 
-      if !*aborted {
-        non_aborted_valve_exists = true;
-      } 
-    }
-  } else { 
-    // we can assume that no abort stage has been set, therefore we just depower. 
-    // also enter this case in a servo to fc (mc to pad) disconnect
-    for i in 1..7 {
-      actuate_valve(i, false); // turn off all valves
-    }
+    // if no non-aborted valves exist, we have aborted all valves
+    *all_valves_aborted = !non_aborted_valve_exists;
   }
-
-  *all_valves_aborted = !non_aborted_valve_exists;
 }
 
 pub fn init_gpio() {

--- a/sam/src/command.rs
+++ b/sam/src/command.rs
@@ -29,9 +29,9 @@ pub fn execute(command: SamControlMessage, abort_info: &mut AbortInfo, abort_val
         &mut abort_info.received_abort,
       );
     },
-    SamControlMessage::Abort { use_stage_timers } => {
+    SamControlMessage::Abort {} => {
       abort_info.time_aborted = Some(Instant::now()); // do this before so timer instantly starts, also to prevent reading stale timer
-      safe_valves(abort_valve_states, &abort_info.time_aborted, &mut abort_info.all_valves_aborted, use_stage_timers);
+      safe_valves(abort_valve_states, &abort_info.time_aborted, &mut abort_info.all_valves_aborted);
       abort_info.received_abort = true; 
     },
     SamControlMessage::ClearStoredAbortStage {  } => {
@@ -60,18 +60,18 @@ fn store_abort_valve_states(desired_valve_states: &Vec<ValveAction>, stored_valv
 
 // Calls safe_valves under the hood, exists primarily for naming convention logic 
 pub fn check_valve_abort_timers(abort_valve_states: &mut Vec<(ValveAction, bool)>, all_valves_aborted: &mut bool, time_aborted: &Option<Instant>) {
-  safe_valves(abort_valve_states, time_aborted, all_valves_aborted, true);
+  safe_valves(abort_valve_states, time_aborted, all_valves_aborted);
 }
 
 // safe the valves by going to safe states (if abort stage is set) or depowering valves
-pub fn safe_valves(abort_valve_states: &mut Vec<(ValveAction, bool)>, time_aborted: &Option<Instant>, all_valves_aborted: &mut bool, use_stage_timers: bool) {
+pub fn safe_valves(abort_valve_states: &mut Vec<(ValveAction, bool)>, time_aborted: &Option<Instant>, all_valves_aborted: &mut bool) {
   let mut non_aborted_valve_exists = false;
   // check if an abort stage has been set (indirectly) by seeing if we have predefined abort valve states
-  if use_stage_timers && !*all_valves_aborted {
+  if !*all_valves_aborted {
     for (valve_info, aborted) in abort_valve_states {
 
       // abort the valve if we want an instant abort OR if our timer is up and we haven't aborted yet
-      if !use_stage_timers || (!*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer)  {
+      if !*aborted && (Instant::now().duration_since(time_aborted.unwrap()) + HEARTBEAT_TIME_LIMIT) > valve_info.timer  {
         actuate_valve(valve_info.channel_num, valve_info.powered);
 
         // mark this valve as aborted 
@@ -117,7 +117,7 @@ pub fn init_gpio() {
   }
 
   // turn off all valves
-  safe_valves(&mut Vec::new(), &None, &mut false, false);
+  safe_valves(&mut Vec::new(), &None, &mut false);
   // initally measure valve currents on valves 1, 3, and 5 for rev4
   reset_valve_current_sel_pins();
 }

--- a/sam/src/communication.rs
+++ b/sam/src/communication.rs
@@ -11,8 +11,6 @@ use std::{
 };
 
 use crate::{command::{execute, check_valve_abort_timers}, state::{AbortInfo, ConnectData}, SamVersion, FC_ADDR, CACHED_FC_ADDRESS};
-use std::thread;
-use std::net::Ipv4Addr;
 
 // const FC_ADDR: &str = "server-01";
 // const FC_ADDR: &str = "flight";

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -218,10 +218,8 @@ fn main_loop(mut data: MainLoopData) -> State {
 
 fn abort(mut data: AbortData) -> State {
   fail!("Aborting goodbye!");
-  // figure out whether we need to use abort stages or not 
-  let use_abort_stages = !data.abort_valve_states.is_empty();
-  // abort valves, either depowering all of them if we do not have any saved abort stage safe states or referring to the saved abort stage safe states
-  safe_valves(&mut data.abort_valve_states, &data.abort_info.time_aborted, &mut data.abort_info.all_valves_aborted, use_abort_stages);
+  // abort valves
+  safe_valves(&mut data.abort_valve_states, &data.abort_info.time_aborted, &mut data.abort_info.all_valves_aborted);
   // reset ADC pin muxing
   reset_adcs(&mut data.adcs);
   // reset pins that select which valve currents are measured from valve driver

--- a/sam/src/state.rs
+++ b/sam/src/state.rs
@@ -191,7 +191,7 @@ fn main_loop(mut data: MainLoopData) -> State {
   // if there are commands, do them!
   check_and_execute(&data.my_command_socket, &mut data.abort_info, &mut data.abort_valve_states);
 
-  // check up on abort valve timers if we have received an abort an all valves have not been aborted
+  // check up on abort valve timers if we have received an abort and all valves have not been aborted
   if data.abort_info.received_abort && !data.abort_info.all_valves_aborted {
     check_valve_abort_timers(&mut data.abort_valve_states, &mut data.abort_info.all_valves_aborted, &data.abort_info.time_aborted);
   }

--- a/servo/src/server/flight.rs
+++ b/servo/src/server/flight.rs
@@ -208,13 +208,9 @@ impl FlightComputer {
     }
   }
 
-  /// Sends a comprehensive update of mappings, triggers, and abort sequence to
-  /// flight.
+  /// Sends a comprehensive update of mappings and triggers to flight.
   pub async fn update(&mut self) -> anyhow::Result<()> {
     self.send_mappings().await?;
-
-    // TODO: send triggers and abort sequence automatically
-
     Ok(())
   }
 }

--- a/servo/src/server/routes/sequence.rs
+++ b/servo/src/server/routes/sequence.rs
@@ -88,19 +88,6 @@ pub async fn save_sequence(
     )
     .map_err(internal)?;
 
-  // if the incoming sequence is the abort sequence, immediately send it over to
-  // flight to be saved, _not run_.
-  if request.name == "abort" {
-    if let Some(flight) = shared.flight.0.lock().await.as_mut() {
-      let sequence = Sequence {
-        name: request.name,
-        script: decoded_script,
-      };
-
-      flight.send_sequence(sequence).await.map_err(internal)?;
-    }
-  }
-
   Ok(())
 }
 
@@ -165,15 +152,6 @@ pub async fn run_sequence(
     .map_err(bad_request)?;
 
   if let Some(flight) = shared.flight.0.lock().await.as_mut() {
-    // special case for abort sequence, because sending it over just saves it
-    // so we need to send an actual abort control message if we want to run it
-    if sequence.name == "abort" {
-      flight.abort().await.map_err(internal)?;
-
-      return Ok(());
-    }
-
-    // otherwise, send the sequence as normal to the flight computer
     flight.send_sequence(sequence).await.map_err(internal)?;
   } else {
     return Err(internal("flight computer not connected"));

--- a/sitl/Isolab.md
+++ b/sitl/Isolab.md
@@ -126,7 +126,7 @@ Current responsibilities:
 Today, the real services are:
 
 - `servo serve --volatile --quiet`
-- `flight-computer --disable-gps desktop`
+- `flight-computer disable-gps desktop`
 
 ## Components
 

--- a/sitl/Isolab.md
+++ b/sitl/Isolab.md
@@ -126,7 +126,7 @@ Current responsibilities:
 Today, the real services are:
 
 - `servo serve --volatile --quiet`
-- `flight-computer disable-gps desktop`
+- `flight-computer disable-gps-reco desktop`
 
 ## Components
 

--- a/sitl/isolab/src/scenarios/mod.rs
+++ b/sitl/isolab/src/scenarios/mod.rs
@@ -51,7 +51,7 @@ impl Harness {
     let flight = process::spawn(ProcessSpec {
       namespace: NS_FLIGHT,
       command: &args.flight_bin,
-      args: &["--disable-gps", "desktop"],
+      args: &["disable-gps", "desktop"],
       envs: &[
         ("HOME", flight_home.to_str().unwrap()),
         ("PYTHONPATH", python_dir.to_str().unwrap()),

--- a/sitl/isolab/src/scenarios/mod.rs
+++ b/sitl/isolab/src/scenarios/mod.rs
@@ -51,7 +51,7 @@ impl Harness {
     let flight = process::spawn(ProcessSpec {
       namespace: NS_FLIGHT,
       command: &args.flight_bin,
-      args: &["disable-gps", "desktop"],
+      args: &["disable-gps-reco", "desktop"],
       envs: &[
         ("HOME", flight_home.to_str().unwrap()),
         ("PYTHONPATH", python_dir.to_str().unwrap()),


### PR DESCRIPTION
This PR includes code changes from dev/AVI-291 (https://github.com/gt-space/luna/pull/143) (abort stage refactor / cleanup), dev/AVI-293 (https://github.com/gt-space/luna/pull/144) (flight attempts to reconnect with servo even when `servo_disconnect_monitoring=false`, and dev/AVI-294 (https://github.com/gt-space/luna/pull/145) (adding stackable runtime flags to disable data collection from the imu, magnetometer, barometer, gps+reco, and a general desktop flag that disables all local sensor / serial communication workers). 

Feel free to look at the aforementioned branches' pull requests to see code changes specific to each change in an isolated manner, as well as some more specific testing behavior. This branch has all changes from those branches merged into one branch. 

This is the branch that was used during Darcy WDR, with the only changes made since then being the addition of comments and renaming variables. 

Note:
End goal is to merge this branch into `main`, and close all of the other pull requests with a comment that links this PR . 
