### PR TITLE
FC Multi-directory File Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +558,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -882,6 +902,7 @@ dependencies = [
  "mmap-sync",
  "ms5611",
  "postcard",
+ "rand 0.10.1",
  "reco",
  "serde",
  "socket2 0.5.10",
@@ -1069,6 +1090,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2064,7 +2086,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2486,7 +2508,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2496,7 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2507,6 +2540,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -2729,7 +2768,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2998,7 +3037,7 @@ dependencies = [
  "jeflog",
  "libc",
  "postcard",
- "rand",
+ "rand 0.8.5",
  "ratatui",
  "reqwest",
  "rusqlite",
@@ -3019,7 +3058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3030,7 +3069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3078,7 +3117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3286,7 +3325,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -3325,7 +3364,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -3797,7 +3836,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -4530,7 +4569,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/flight2/Cargo.toml
+++ b/flight2/Cargo.toml
@@ -20,3 +20,6 @@ ms5611 = { version = "0.1.0", path = "../firmware/ms5611" }
 spidev = "0.6.0"
 ads124s06 = { version = "0.1.0", path = "../firmware/ads124s06" }
 tempfile = "3.27.0"
+
+[dev-dependencies]
+rand = "0.10.1"

--- a/flight2/README.md
+++ b/flight2/README.md
@@ -10,7 +10,7 @@ From the **workspace root** (`luna/`):
 cargo run -p flight-computer --release
 ```
 
-From `**flight2/**`:
+From `luna/flight2/`:
 
 ```bash
 cargo run --release
@@ -46,13 +46,13 @@ cargo run -p flight-computer --release -- desktop
 
 ### Build only, then run
 
-`cargo build` does not accept program arguments like `desktop`; it only compiles.
+`cargo build` does not accept program arguments like `desktop`as those are runtime commands. To use runtime commands while building, compile first:
 
 ```bash
 cargo build -p flight-computer --release
 ```
 
-Then run the release binary from the workspace root (artifact path is under `target/release/`). A few examples of some subcommands that you can run the binary with are also listed:
+Then run the release binary from the workspace root (artifact path is under `luna/target/release/`). A few examples of some subcommands that you can run the binary with are also listed:
 
 ```bash
 ./target/release/flight-computer
@@ -68,10 +68,11 @@ If you built from inside `flight2/`, the binary is still emitted at the workspac
 The binary also accepts global flags in addition to the runtime commands above:
 
 - `--disable-file-logging` turns off on-disk vehicle-state logging.
-- `--log-dir <PATH>` writes logs to a custom directory instead of `$HOME/flight_logs`.
-    - This command is stackable! For instance, if you want to write to multiple log directories, you can do `--log-dir <PATH1> --log-dir <PATH2> --log-dir <PATH3> ...`
+- `--log-dirs <PATH>` writes logs to a custom directory instead of `$HOME/flight_logs`.
+  - This flag is stackable. Repeat it to mirror logs to multiple directories.
 - `--log-buffer-size <N>` changes the in-memory logging channel size. Default: `100`.
 - `--log-rotation-mb <N>` rotates to a new log file once the current file reaches `N` MB. Default: `100`.
+- `--fsync-rate <N>` forces buffered log data to sync to disk every `N` internal flushes. Default: `0` (disabled).
 - `--print-gps` prints GPS data to the terminal at about 1 Hz.
 
 Flags can be used on their own or combined with runtime commands such as `desktop`
@@ -89,8 +90,16 @@ cargo run -p flight-computer --release
 Write logs to a specific directory:
 
 ```bash
-cargo run -p flight-computer --release -- --log-dir /home/ubuntu/flight_logs
-./target/release/flight-computer --log-dir /home/ubuntu/flight_logs
+cargo run -p flight-computer --release -- --log-dirs /home/ubuntu/flight_logs
+./target/release/flight-computer --log-dirs /home/ubuntu/flight_logs
+```
+
+Write the same logs to multiple directories, such as both blackbox SD card
+mounts on the Raspberry Pi:
+
+```bash
+cargo run -p flight-computer --release -- --log-dirs /mnt/blackbox_a --log-dirs /mnt/blackbox_b
+./target/release/flight-computer --log-dirs /mnt/blackbox_a --log-dirs /mnt/blackbox_b
 ```
 
 Rotate files at 25 MB instead of the default 100 MB:
@@ -117,6 +126,25 @@ cargo run -p flight-computer --release -- --disable-file-logging
 Combine logging flags with runtime commands:
 
 ```bash
-cargo run -p flight-computer --release -- --log-dir /home/ubuntu/flight_logs disable-imu disable-magnetometer
-./target/release/flight-computer --log-dir /home/ubuntu/flight_logs disable-imu disable-magnetometer
+cargo run -p flight-computer --release -- --log-dirs /home/ubuntu/flight_logs disable-imu disable-magnetometer
+./target/release/flight-computer --log-dirs /home/ubuntu/flight_logs disable-imu disable-magnetometer
 ```
+
+### Raspberry Pi Blackbox Mounts
+
+`scripts/mount_blackbox.sh` prepares two removable storage locations for file
+logging on the Raspberry Pi. These locations are hardcoded, and correspond to 
+the column of USB ports that are closest to the ethernet port on a pi5.
+The script is intended to run from a systemd service during boot, wait briefly 
+for block devices to appear, create the mount directories, and mount:
+
+- `/dev/sda1` at `/mnt/blackbox_a`
+- `/dev/sdb1` at `/mnt/blackbox_b`
+
+Once those mount points are available, start the flight computer with both paths
+listed under `--log-dirs` to mirror logs to both SD cards:
+
+```bash
+./target/release/flight-computer --log-dirs /mnt/blackbox_a --log-dirs /mnt/blackbox_b
+```
+

--- a/flight2/README.md
+++ b/flight2/README.md
@@ -69,6 +69,7 @@ The binary also accepts global flags in addition to the runtime commands above:
 
 - `--disable-file-logging` turns off on-disk vehicle-state logging.
 - `--log-dir <PATH>` writes logs to a custom directory instead of `$HOME/flight_logs`.
+    - This command is stackable! For instance, if you want to write to multiple log directories, you can do `--log-dir <PATH1> --log-dir <PATH2> --log-dir <PATH3> ...`
 - `--log-buffer-size <N>` changes the in-memory logging channel size. Default: `100`.
 - `--log-rotation-mb <N>` rotates to a new log file once the current file reaches `N` MB. Default: `100`.
 - `--print-gps` prints GPS data to the terminal at about 1 Hz.

--- a/flight2/scripts/mount_blackbox.sh
+++ b/flight2/scripts/mount_blackbox.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sleep 5
+
+mkdir /mnt/blackbox_a
+mkdir /mnt/blackbox_b
+
+if ! mountpoint -q /mnt/blackbox_a; then
+	mount /dev/sda1 /mnt/blackbox_a
+fi 
+
+if ! mountpoint -q /mnt/blackbox_b; then
+	mount /dev/sdb1 /mnt/blackbox_b
+fi

--- a/flight2/src/cli.rs
+++ b/flight2/src/cli.rs
@@ -110,9 +110,10 @@ impl RuntimeConfig {
       worker_config: WorkerConfig::from_cli_commands(&args.commands),
       logger_config: LoggerConfig::from_cli_commands(
         args.disable_file_logging,
-        args.log_dir,
+        args.log_dirs,
         args.log_buffer_size,
         args.log_rotation_mb,
+        args.fsync_rate
       ),
       print_gps: args.print_gps,
     }
@@ -131,9 +132,9 @@ struct Args {
   #[arg(long, default_value_t = false, global = true)]
   disable_file_logging: bool,
 
-  /// Directory for log files (default: $HOME/flight_logs)
+  /// Directories for log files (default: $HOME/flight_logs)
   #[arg(long, global = true)]
-  log_dir: Option<PathBuf>,
+  log_dirs: Option<Vec<PathBuf>>,
 
   /// Buffer size in samples (default: 100)
   #[arg(long, default_value_t = 100, global = true)]
@@ -146,6 +147,11 @@ struct Args {
   /// Print GPS data to terminal at ~1Hz (disabled by default)
   #[arg(long, default_value_t = false, global = true)]
   print_gps: bool,
+
+  /// How often log data should be written to disk after flushing the internal 
+  /// buffer `fsync_rate` times (disabled by default)
+  #[arg(long, default_value_t = 0, global = false)]
+  fsync_rate: usize
 }
 
 pub fn parse() -> RuntimeConfig {

--- a/flight2/src/file_logger.rs
+++ b/flight2/src/file_logger.rs
@@ -1,6 +1,6 @@
 use std::{
   fs::{self, File},
-  io::{BufWriter, Write},
+  io::{self, Write},
   path::{Path, PathBuf},
   sync::mpsc::{self, TrySendError},
   thread,
@@ -11,7 +11,7 @@ use common::comm::VehicleState;
 use serde::{Deserialize, Serialize};
 
 /// A VehicleState with a timestamp attached for logging purposes
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct TimestampedVehicleState {
   /// Unix timestamp in seconds with nanosecond precision
   pub timestamp: f64,
@@ -24,8 +24,8 @@ pub struct TimestampedVehicleState {
 pub struct LoggerConfig {
   /// Whether file logging is enabled
   pub enabled: bool,
-  /// Directory where log files are stored
-  pub log_dir: PathBuf,
+  /// Directories where log files are stored
+  pub log_dirs: Vec<PathBuf>,
   /// Maximum number of samples to buffer in the channel
   pub channel_capacity: usize,
   /// Number of samples to batch before writing
@@ -34,17 +34,21 @@ pub struct LoggerConfig {
   pub batch_timeout: Duration,
   /// Maximum file size in bytes before rotation
   pub file_size_limit: usize,
+  /// Ensure the log data is written to disk every time we flush our internal 
+  /// buffer `fsync_rate` times. If zero, this functionality is disabled.
+  pub fsync_rate: usize,
 }
 
 impl Default for LoggerConfig {
   fn default() -> Self {
     Self {
       enabled: true,
-      log_dir: default_log_dir(),
+      log_dirs: default_log_dir(),
       channel_capacity: 100,
       batch_size: 50,
       batch_timeout: Duration::from_millis(500),
       file_size_limit: 100 * 1024 * 1024, // 100MB
+      fsync_rate: 0
     }
   }
 }
@@ -54,28 +58,32 @@ impl LoggerConfig {
   /// (`disable-file-logging`, `log-dir`, `log-buffer-size`, `log-rotation-mb`).
   pub fn from_cli_commands(
     disable_file_logging: bool,
-    log_dir: Option<PathBuf>,
+    log_dirs: Option<Vec<PathBuf>>,
     log_buffer_size: usize,
     log_rotation_mb: u64,
+    fsync_rate: usize
   ) -> Self {
     Self {
       enabled: !disable_file_logging,
-      log_dir: log_dir.unwrap_or_else(|| {
-        std::env::var("HOME")
+      // TODO: use default_log_dir if unwrap fails?
+      log_dirs: log_dirs.unwrap_or_else(|| {
+        vec![std::env::var("HOME")
           .map(PathBuf::from)
           .unwrap_or_else(|_| PathBuf::from("."))
-          .join("flight_logs")
+          .join("flight_logs")]
       }),
       channel_capacity: log_buffer_size,
       batch_size: (log_buffer_size / 2).clamp(10, 100),
       batch_timeout: Duration::from_millis(500),
       file_size_limit: (log_rotation_mb as usize) * 1024 * 1024,
+      fsync_rate,
     }
   }
 }
 
-fn default_log_dir() -> PathBuf {
-  PathBuf::from("/home/ubuntu/flight_logs")
+fn default_log_dir() -> Vec<PathBuf> {
+  // TODO: Rewrite this to use $HOME?, similarly to 
+  vec![PathBuf::from("/home/ubuntu/flight_logs")]
 }
 
 /// Error types for file logger operations
@@ -118,6 +126,190 @@ pub struct FileLogger {
   handle: Option<thread::JoinHandle<()>>,
 }
 
+struct LogFileBuffer {
+  directories: Vec<PathBuf>,
+  files: Vec<LogFile>,
+  buffer: Vec<TimestampedVehicleState>,
+  size: usize,
+  last_flush: Instant,
+}
+
+impl LogFileBuffer {
+  pub fn new(directories: Vec<PathBuf>, batch_size: usize) -> LogFileBuffer {
+    LogFileBuffer {
+      files: directories.iter().map(|p| LogFile::new(&create_log_file_path(p))).collect(),
+      directories,
+      buffer: Vec::with_capacity(batch_size),
+      size: 0,
+      last_flush: Instant::now(),
+    }
+  }
+
+  pub fn flush_buffer(&mut self) {
+    if self.is_empty() {
+      return;
+    }
+
+    let mut buf = Vec::new();
+    for state in self.buffer.drain(..) {
+      let serialized = match postcard::to_allocvec(&state) {
+        Ok(s) => s,
+        Err(e) => {
+          eprintln!("Failed to serialize VehicleState for file log: {e}");
+          continue;
+        }
+      };
+
+      buf.extend(serialized.len().to_le_bytes());
+      buf.extend(serialized);
+    }
+
+    for log_file in &mut self.files {
+      if !log_file.is_open() {
+        if let Err(e) = log_file.open() {
+          eprintln!("Failed to open log file {} for writing: {e}", log_file.path.display());
+        }
+      }
+
+      if let Err(e) = log_file.write(&buf[..]) {
+        eprintln!("Failed to write to log file {}: {e}", log_file.path.display());
+      }
+    }
+
+    self.last_flush = Instant::now();
+    self.size += buf.len();
+  }
+
+  pub fn rotate_files(&mut self) {
+    for (file, log_dir) in self.files.iter_mut().zip(self.directories.iter()) {
+      file.close();
+      file.set_path(&create_log_file_path(log_dir));
+      if let Err(e) = file.open() {
+        eprintln!("Failed to open new log file: {e}");
+      }
+    }
+
+    self.size = 0;
+  }
+
+  pub fn sync_to_disk(&mut self) {
+    for log_file in &mut self.files {
+      if let Err(e) = log_file.sync_to_disk() {
+        eprintln!("Failed to write {} to disk: {e}", log_file.path.display());
+      }
+    }
+  }
+
+  /// Returns the number of VehicleState structs currently in the buffer.
+  pub fn states_in_flight(&self) -> usize {
+    self.buffer.len()
+  }
+
+  pub fn last_flush(&self) -> Instant {
+    self.last_flush
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.buffer.is_empty()
+  }
+
+  pub fn file_size(&self) -> usize {
+    self.size
+  }
+
+  pub fn push(&mut self, state: TimestampedVehicleState) {
+    self.buffer.push(state);
+  }
+}
+
+struct LogFile {
+  path: PathBuf,
+  file: Option<File>,
+}
+
+/// The result of a write operation on a LogFile.
+type LogFileWriteResult<T> = ::std::result::Result<T, LogFileWriteError>;
+
+/// The specific error of a write operation on a LogFile.
+enum LogFileWriteError {
+  /// The log file is already open.
+  Open,
+  /// The log file is not open.
+  NotOpen,
+  /// An I/O error occured while trying to flush. 
+  IoError(io::Error)
+}
+
+impl From<io::Error> for LogFileWriteError {
+  fn from(value: io::Error) -> Self {
+      Self::IoError(value)
+  }
+}
+
+impl std::fmt::Display for LogFileWriteError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::IoError(e) => write!(f, "{e}"),
+      Self::NotOpen => write!(f, "The log file is not open."),
+      Self::Open => write!(f, "The log file is open"),
+    }
+  }
+}
+
+impl LogFile {
+  pub fn new(path: &Path) -> Self {
+    LogFile {
+      path: path.to_path_buf(),
+      file: None,
+    }
+  }
+
+  /// Opens a log file using the set path.
+  pub fn open(&mut self) -> LogFileWriteResult<()> {
+    if self.is_open() {
+      return Err(LogFileWriteError::Open);
+    }
+
+    self.file = Some(File::create(&self.path)?);
+    Ok(())
+  }
+
+  pub fn is_open(&self) -> bool {
+    self.file.is_some()
+  }
+
+  /// Writes the passed data to the log if a log is open.
+  pub fn write(&mut self, data: &[u8]) -> LogFileWriteResult<()> {
+    let Some(ref mut file) = self.file else {
+      return Err(LogFileWriteError::NotOpen);
+    };
+    
+    file.write_all(data)?;
+    Ok(())
+  }
+
+  /// Sets the internal path to the passed path.
+  pub fn set_path(&mut self, path: &Path) {
+    self.close();
+    self.path = path.to_path_buf();
+  }
+
+  /// Closes the file. Does not fsync file contents to disk upon closing.
+  pub fn close(&mut self) {
+    self.file.take();
+  }
+
+  /// Ensures that any cached data related to the log file is written to disk
+  /// upon returning.
+  pub fn sync_to_disk(&mut self) -> LogFileWriteResult<()> {    
+    let Some(ref file) = self.file else {
+      return Err(LogFileWriteError::NotOpen);
+    };
+
+    Ok(file.sync_all()?)
+  }
+}
+
 impl FileLogger {
   /// Create a new file logger with the given configuration
   pub fn new(config: LoggerConfig) -> Result<Self, LoggerError> {
@@ -137,20 +329,16 @@ impl FileLogger {
       });
     }
 
-    // Ensure log directory exists
-    fs::create_dir_all(&config.log_dir).map_err(|e| LoggerError::IoError(e))?;
-
-    // Create initial log file with timestamp
-    let file_path = create_log_file_path(&config.log_dir)?;
+    // Ensure log directories exist
+    for directory in &config.log_dirs {
+      fs::create_dir_all(directory)?;
+    }
 
     // Use bounded channel to prevent unbounded memory growth
     let (sender, receiver) = mpsc::sync_channel(config.channel_capacity);
 
-    // Clone config for the background thread
-    let thread_config = config.clone();
-
     let handle = thread::spawn(move || {
-      Self::writer_thread(receiver, thread_config, file_path);
+      Self::writer_thread(receiver, config);
     });
 
     Ok(Self {
@@ -186,24 +374,19 @@ impl FileLogger {
   /// Background writer thread that handles batching and file I/O
   fn writer_thread(
     receiver: mpsc::Receiver<TimestampedVehicleState>,
-    config: LoggerConfig,
-    initial_file_path: PathBuf,
+    config: LoggerConfig
   ) {
-    let mut current_file_path = initial_file_path;
-    let mut current_file: Option<BufWriter<File>> = None;
-    let mut batch: Vec<TimestampedVehicleState> =
-      Vec::with_capacity(config.batch_size);
-    let mut last_flush = Instant::now();
-    let mut file_size: usize = 0;
+    let mut log_buffer = LogFileBuffer::new(config.log_dirs, config.batch_size);
+    let is_disk_sync_enabled = config.fsync_rate != 0;
+    let mut flush_counter: usize = 0;
 
-    loop {
+    'a: loop {
       // Check for batch timeout
-      let elapsed = last_flush.elapsed();
+      let elapsed = log_buffer.last_flush().elapsed();
       let should_flush_timeout = elapsed >= config.batch_timeout;
-      let should_flush_batch = batch.len() >= config.batch_size;
 
       // Try to receive with timeout
-      let timeout = if should_flush_timeout || should_flush_batch {
+      let timeout = if should_flush_timeout {
         Duration::ZERO
       } else {
         config.batch_timeout - elapsed
@@ -211,152 +394,45 @@ impl FileLogger {
 
       match receiver.recv_timeout(timeout) {
         Ok(state) => {
-          batch.push(state);
+          log_buffer.push(state);
         }
         Err(mpsc::RecvTimeoutError::Timeout) => {
           // Timeout - flush if we have data
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
           // Channel closed - flush remaining data and exit
-          if !batch.is_empty() {
-            Self::write_batch(
-              &mut current_file,
-              &mut current_file_path,
-              &mut batch,
-              &mut file_size,
-              &config,
-            );
+          log_buffer.flush_buffer();
+          if is_disk_sync_enabled {
+            log_buffer.sync_to_disk();
           }
-          break;
+          break 'a;
         }
       }
 
+      let should_flush_batch = log_buffer.states_in_flight() >= config.batch_size;
       // Flush if needed
       if should_flush_timeout || should_flush_batch {
-        if !batch.is_empty() {
-          Self::write_batch(
-            &mut current_file,
-            &mut current_file_path,
-            &mut batch,
-            &mut file_size,
-            &config,
-          );
-          last_flush = Instant::now();
-        }
+        log_buffer.flush_buffer();
+        flush_counter += 1;
       }
 
       // Check if we need to rotate the file
-      if file_size >= config.file_size_limit {
-        Self::rotate_file(
-          &mut current_file,
-          &mut current_file_path,
-          &mut file_size,
-          &config,
-        );
+      if log_buffer.file_size() >= config.file_size_limit {
+        log_buffer.rotate_files();
+      }
+
+      // Check if we need to sync our data to disk.
+      if is_disk_sync_enabled && flush_counter == config.fsync_rate {
+        log_buffer.sync_to_disk();
+        flush_counter = 0;
       }
     }
 
     // Flush any remaining data
-    if let Some(ref mut writer) = current_file {
-      let _ = writer.flush();
+    log_buffer.flush_buffer();
+    if is_disk_sync_enabled {
+      log_buffer.sync_to_disk();
     }
-  }
-
-  /// Write a batch of timestamped states to the current file
-  fn write_batch(
-    current_file: &mut Option<BufWriter<File>>,
-    current_file_path: &mut PathBuf,
-    batch: &mut Vec<TimestampedVehicleState>,
-    file_size: &mut usize,
-    config: &LoggerConfig,
-  ) {
-    // Ensure file is open
-    if current_file.is_none() {
-      match Self::open_file(current_file_path, config) {
-        Ok(file) => *current_file = Some(file),
-        Err(e) => {
-          eprintln!("Failed to open log file {:?}: {}", current_file_path, e);
-          batch.clear(); // Drop batch on error
-          return;
-        }
-      }
-    }
-
-    let writer = current_file.as_mut().unwrap();
-
-    // Serialize and write each state in the batch
-    for state in batch.drain(..) {
-      match postcard::to_allocvec(&state) {
-        Ok(serialized) => {
-          // Write length prefix (u64)
-          let len = serialized.len() as u64;
-          if let Err(e) = writer.write_all(&len.to_le_bytes()) {
-            eprintln!("Failed to write length prefix: {}", e);
-            continue;
-          }
-
-          // Write serialized data
-          if let Err(e) = writer.write_all(&serialized) {
-            eprintln!("Failed to write data: {}", e);
-            continue;
-          }
-
-          *file_size += 8 + serialized.len(); // 8 bytes for length + data
-        }
-        Err(e) => {
-          eprintln!("Failed to serialize state: {}", e);
-        }
-      }
-    }
-
-    // Flush the writer (but don't sync, for performance)
-    if let Err(e) = writer.flush() {
-      eprintln!("Failed to flush log file: {}", e);
-    }
-  }
-
-  /// Rotate to a new file when size limit is reached
-  fn rotate_file(
-    current_file: &mut Option<BufWriter<File>>,
-    current_file_path: &mut PathBuf,
-    file_size: &mut usize,
-    config: &LoggerConfig,
-  ) {
-    // Close current file
-    if let Some(mut writer) = current_file.take() {
-      let _ = writer.flush();
-    }
-
-    // Create new file
-    match Self::open_file_path(config) {
-      Ok(new_path) => {
-        *current_file_path = new_path;
-        *file_size = 0;
-        match Self::open_file(&current_file_path, config) {
-          Ok(file) => *current_file = Some(file),
-          Err(e) => {
-            eprintln!("Failed to open new log file: {}", e);
-          }
-        }
-      }
-      Err(e) => {
-        eprintln!("Failed to create new log file path: {}", e);
-      }
-    }
-  }
-
-  /// Open a file for writing at the given path
-  fn open_file(
-    path: &Path,
-    _config: &LoggerConfig,
-  ) -> Result<BufWriter<File>, std::io::Error> {
-    let file = File::create(path)?;
-    Ok(BufWriter::with_capacity(256 * 1024, file)) // 256KB buffer
-  }
-
-  /// Generate a new log file path with current timestamp
-  fn open_file_path(config: &LoggerConfig) -> Result<PathBuf, LoggerError> {
-    Ok(create_log_file_path(&config.log_dir)?)
   }
 
   /// Shutdown the logger gracefully, flushing all pending data
@@ -367,8 +443,7 @@ impl FileLogger {
     // Wait for thread to finish
     if let Some(handle) = self.handle {
       handle.join().map_err(|_| {
-        LoggerError::IoError(std::io::Error::new(
-          std::io::ErrorKind::Other,
+        LoggerError::IoError(std::io::Error::other(
           "Logger thread panicked",
         ))
       })?;
@@ -379,14 +454,14 @@ impl FileLogger {
 }
 
 /// Create a log file path with current timestamp
-fn create_log_file_path(log_dir: &Path) -> Result<PathBuf, LoggerError> {
+fn create_log_file_path(log_dir: &Path) -> PathBuf {
   use chrono::Local;
 
   // Format: flight_data_YYYYMMDD_HHMMSS.postcard
   let now = Local::now();
   let timestamp_str = now.format("%Y%m%d_%H%M%S").to_string();
   let filename = format!("flight_data_{}.postcard", timestamp_str);
-  Ok(log_dir.join(filename))
+  log_dir.join(filename)
 }
 
 /// Get current timestamp as f64 (seconds since epoch with nanosecond precision)
@@ -395,4 +470,250 @@ pub fn current_timestamp() -> f64 {
     .duration_since(UNIX_EPOCH)
     .map(|t| Duration::as_secs_f64(&t))
     .unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests{
+  use std::{collections::HashMap, io::{BufReader, Read}, sync::mpsc::SyncSender};
+  use super::*;
+
+  const HOME_DIRECTORY: &str = "/tmp/fc2_file_logger_test";
+
+  fn generate_random_vehiclestates<F>(quantity: usize, mut closure: F) -> Vec<TimestampedVehicleState>
+  where F: FnMut(TimestampedVehicleState) {
+    let mut monostate = VehicleState::new();
+    let mut states = Vec::new();
+    for _ in 0..quantity {
+      monostate.bms.battery_bus.current = rand::random();
+      monostate.bms.battery_bus.voltage = rand::random();
+      monostate.bms.charger = rand::random();
+      monostate.bms.chassis = rand::random();
+      monostate.bms.e_stop = rand::random();
+      monostate.bms.ethernet_bus.current = rand::random();
+      monostate.bms.ethernet_bus.voltage = rand::random();
+      monostate.bms.fcb_bus.voltage = rand::random();
+      monostate.bms.fcb_bus.current = rand::random();
+      monostate.bms.five_volt_rail.current = rand::random();
+      monostate.bms.five_volt_rail.voltage = rand::random();
+      monostate.bms.rbf_tag = rand::random();
+      monostate.bms.reco_load_switch_1 = rand::random();
+      monostate.bms.reco_load_switch_2 = rand::random();
+      monostate.bms.sam_power_bus.current = rand::random();
+      monostate.bms.sam_power_bus.voltage = rand::random();
+      monostate.bms.tel_bus.current = rand::random();
+      monostate.bms.tel_bus.voltage = rand::random();
+      monostate.bms.umbilical_bus.current = rand::random();
+      monostate.bms.umbilical_bus.voltage = rand::random();
+
+      let state = TimestampedVehicleState { 
+        timestamp: current_timestamp(),
+        state: monostate.clone(),
+      };
+
+      states.push(state.clone());
+      closure(state);
+    }
+
+    states
+  }
+
+  fn random_string(length: usize) -> String {
+    let mut vec = Vec::new();
+    for _ in 0..length {
+      vec.push(rand::random_range(97u8..=122u8));
+    }
+    String::from_utf8(vec).unwrap()
+  }
+
+  fn create_log_dirs(paths: &[&str]) -> (PathBuf, Vec<PathBuf>) {
+    let parent = PathBuf::from(HOME_DIRECTORY).join(random_string(16));
+    let directories = paths.iter().map(|p| parent.join(p)).collect::<Vec<_>>();
+    for directory in &directories {
+      fs::create_dir_all(directory).unwrap();
+    }
+    
+    (parent.clone(), directories)
+  }
+
+  fn create_channel_and_thread(config: LoggerConfig) -> SyncSender<TimestampedVehicleState> {
+    let (sender, receiver) = 
+      mpsc::sync_channel::<TimestampedVehicleState>(config.channel_capacity);
+    thread::spawn(move || FileLogger::writer_thread(receiver, config));
+    sender
+  }
+
+  fn deserialize_log_file(file: &File) -> Vec<TimestampedVehicleState> {
+    let mut states = Vec::new();
+    let mut state_buf = [0u8; 5_000];
+    let mut contents = BufReader::new(file);
+    
+    loop {
+      let mut len_buf = [0u8; 8];
+      match contents.read_exact(&mut len_buf) {
+        Ok(()) => {},
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+        Err(e) => panic!("{e}"),
+      };
+      let state_length = usize::from_le_bytes(len_buf);
+
+      contents.read_exact(&mut state_buf[..state_length]).unwrap();
+      states.push(postcard::from_bytes(&state_buf[..state_length]).unwrap());
+    }
+
+    states
+  }
+
+  fn open_files(parent: &Path, paths: &[&str]) -> HashMap<String, Vec<File>> {
+    let mut res = HashMap::new();
+
+    for path in paths {
+      let walker = fs::read_dir(parent.join(path).as_path()).unwrap();
+      let mut paths: Vec<PathBuf> = walker
+        .into_iter()
+        .map(|d| d.unwrap().path())
+        .collect();
+      paths.sort();
+      let files = paths.into_iter().map(|p| File::open(p).unwrap()).collect();
+      res.insert(path.to_string(), files);
+    }
+
+    res
+  }
+
+  fn log_write_integration(paths: &[&str], fsync_rate: usize) {
+    let (parent, log_dirs) = create_log_dirs(paths);
+
+    let config = LoggerConfig {
+      fsync_rate,
+      log_dirs,
+      batch_size: 100,
+      file_size_limit: 100 * 1024,
+      batch_timeout: Duration::MAX,
+      ..Default::default()
+    };
+
+    let sender = create_channel_and_thread(config.clone());
+
+    let mut states = generate_random_vehiclestates(config.batch_size / 2, |s| {
+      let _ = sender.send(s);
+    });
+
+    let state_size = postcard::to_allocvec(&states[0]).unwrap().len();
+    thread::sleep(Duration::from_millis(100));
+
+    let directories = open_files(parent.as_path(), paths);
+    for files in directories.values() {
+      assert_eq!(files.len(), 0, "When only writing part of the buffer, it should not write to the filesystem.");
+    }
+    
+    states.extend(generate_random_vehiclestates(config.batch_size, |s| {
+      sender.send(s).unwrap();
+    }));
+    thread::sleep(Duration::from_millis(200));
+
+    let directories = open_files(parent.as_path(), paths);
+    for files in directories.values() {
+      assert_eq!(files.len(), 1, "Only one file should exist when the buffers first gets flushed");
+      let file = files.last().unwrap();
+      let observed_states = deserialize_log_file(file);
+
+      assert_eq!(observed_states.len(), config.batch_size, "The length of the log doesn't match the expected length");
+      for (observed, expected) in observed_states.iter().zip(states.iter().take(config.batch_size)) {
+        assert_eq!(observed, expected, "The expected state and logged state are not equal");
+      }
+    }
+
+    thread::sleep(Duration::from_secs(1));
+    let written = (config.batch_size + config.batch_size / 2) * state_size;
+    let amount_to_rotate = (config.file_size_limit - written) / state_size + config.batch_size;
+    states.extend(generate_random_vehiclestates(amount_to_rotate, |s| {
+      sender.send(s).unwrap();
+      thread::sleep(Duration::from_micros(50));
+    }));
+    let total = (config.batch_size + config.batch_size / 2 + amount_to_rotate) / config.batch_size * config.batch_size;
+
+    let directories = open_files(parent.as_path(), paths);
+    for files in directories.values() {
+      assert_eq!(files.len(), 2, "Two files should exist when the log gets rotated");
+      let mut observed_states = Vec::new();
+      for file in files {
+        observed_states.extend(deserialize_log_file(file));
+      }
+
+      assert_eq!(observed_states.len(), total, "The length of the log doesn't match the expected length");
+      for (observed, expected) in observed_states.iter().zip(states.iter().take(config.batch_size)) {
+        assert_eq!(observed, expected, "The expected state and logged state are not equal");
+      }
+    }
+  }
+
+  fn log_write_flush_timeout(paths: &[&str], fsync_rate: usize) {
+    let (parent, log_dirs) = create_log_dirs(paths);
+
+    let config = LoggerConfig {
+      fsync_rate,
+      log_dirs,
+      batch_size: 100,
+      batch_timeout: Duration::from_millis(100),
+      ..Default::default()
+    };
+
+    let sender = create_channel_and_thread(config.clone());
+    let states = generate_random_vehiclestates(config.batch_size / 2, |s| {
+      let _ = sender.send(s);
+    });
+
+    thread::sleep(Duration::from_millis(500));
+    let directories = open_files(parent.as_path(), paths);
+    for files in directories.values() {
+      assert_eq!(files.len(), 1, "When writing part of the buffer with timeout, it should write to the filesystem.");
+      let file = files.last().unwrap();
+      let observed_states = deserialize_log_file(file);
+
+      assert_eq!(observed_states.len(), config.batch_size / 2, "The length of the log doesn't match the expected length");
+      for (observed, expected) in observed_states.iter().zip(states.iter().take(config.batch_size)) {
+        assert_eq!(observed, expected, "The expected state and logged state are not equal");
+      }
+    }
+  }
+
+  #[test]
+  fn single_write_no_fsync() {
+    log_write_integration(&["os"], 0);
+  }
+
+  #[test]
+  fn single_write_fsync() {
+    log_write_integration(&["os"], 1);
+  }
+
+  #[test]
+  fn multi_write_no_fsync() {
+    log_write_integration(&["os", "blackbox1", "blackbox2", "blackbox3"], 0);
+  }
+
+  #[test]
+  fn multi_write_fsync() {
+    log_write_integration(&["os", "blackbox1", "blackbox2", "blackbox3"], 1);
+  }
+
+  #[test]
+  fn timeout_single_write_no_fsync() {
+    log_write_flush_timeout(&["os"], 0);
+  }
+
+  #[test]
+  fn timeout_single_write_fsync() {
+    log_write_flush_timeout(&["os"], 1);
+  }
+
+  #[test]
+  fn timeout_multi_write_no_fsync() {
+    log_write_flush_timeout(&["os", "blackbox1", "blackbox2", "blackbox3"], 0);
+  }
+
+  #[test]
+  fn timeout_multi_write_fsync() {
+    log_write_flush_timeout(&["os", "blackbox1", "blackbox2", "blackbox3"], 1);
+  }
 }

--- a/flight2/src/file_logger.rs
+++ b/flight2/src/file_logger.rs
@@ -147,6 +147,7 @@ impl LogFileBuffer {
 
   pub fn flush_buffer(&mut self) {
     if self.is_empty() {
+      self.last_flush = Instant::now();
       return;
     }
 

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -312,25 +312,26 @@ fn main() -> ! {
         }
         FlightControlMessage::Trigger(_) => todo!(),
         FlightControlMessage::Mappings(m) => {
-	  if m != mappings {
-          mappings = m;
-          devices.sync_configured_valves(&mappings);
+          // duplicate mappings don't require abort stage to be reset
+          if m != mappings {
+            mappings = m;
+            devices.sync_configured_valves(&mappings);
 
-          // send clear message to sams. this is needed as with new mappings we
-          // restart the abort stage sequence and are in the default
-          // stage again.
-          devices.send_sam_clear_abort_stage(&socket);
+            // send clear message to sams. this is needed as with new mappings we
+            // restart the abort stage sequence and are in the default
+            // stage again.
+            devices.send_sam_clear_abort_stage(&socket);
 
-          // restart the abort stage sequence
-          start_abort_stage_process(
-            &mut abort_stages,
-            &mappings,
-            &mut sequences,
-            &mut devices,
-          );
-} else {
-	println!("Same mappings submitted!");
-}
+            // restart the abort stage sequence
+            start_abort_stage_process(
+              &mut abort_stages,
+              &mappings,
+              &mut sequences,
+              &mut devices,
+            );
+          } else {
+            println!("Same mappings re-submitted!");
+          }
         }
         FlightControlMessage::Sequence(ref s) => {
           sequence::execute(&mappings, s, &mut sequences)

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -154,8 +154,8 @@ fn main() -> ! {
     Ok(logger) => {
       if file_logger_config.enabled {
         println!(
-          "File logging enabled. Log directory: {:?}",
-          file_logger_config.log_dir
+          "File logging enabled. Log directories: {:?}",
+          file_logger_config.log_dirs
         );
       }
       Some(logger)

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -312,6 +312,7 @@ fn main() -> ! {
         }
         FlightControlMessage::Trigger(_) => todo!(),
         FlightControlMessage::Mappings(m) => {
+	  if m != mappings {
           mappings = m;
           devices.sync_configured_valves(&mappings);
 
@@ -327,6 +328,9 @@ fn main() -> ! {
             &mut sequences,
             &mut devices,
           );
+} else {
+	println!("Same mappings submitted!");
+}
         }
         FlightControlMessage::Sequence(ref s) => {
           sequence::execute(&mappings, s, &mut sequences)

--- a/gui/src/avi/RbfStatusValue.tsx
+++ b/gui/src/avi/RbfStatusValue.tsx
@@ -1,9 +1,13 @@
 import { rbfStatusTextColor } from "./rbfDisplay";
 
 export function RbfStatusValue(props: { text: string }) {
-  const col = rbfStatusTextColor(props.text);
   return (
-    <div class="adc-data-value" style={col ? { color: col } : undefined}>
+    <div
+      class="adc-data-value"
+      style={{
+        color: rbfStatusTextColor(props.text),
+      }}
+    >
       {props.text}
     </div>
   );

--- a/gui/src/avi/ahrs/ahrs.tsx
+++ b/gui/src/avi/ahrs/ahrs.tsx
@@ -24,13 +24,10 @@ const [ahrsData, setAhrsData] = createSignal({
 listen('device_update', (event) => {
   // get sensor data
   const ahrs_object = (event.payload as StreamState).ahrs;
-  console.log(event.payload);
-  console.log(ahrs_object)
   setAhrsData(ahrs_object);
 });
 
 listen('state', (event) => {
-  console.log(event.windowLabel);
   setConfigurations((event.payload as State).configs);
   setActiveConfig((event.payload as State).activeConfig);
 });

--- a/gui/src/avi/bms/bms.tsx
+++ b/gui/src/avi/bms/bms.tsx
@@ -32,13 +32,11 @@ const [bmsData, setBmsData] = createSignal({
 listen('device_update', (event) => {
   // get sensor data
   const bms_object = (event.payload as StreamState).bms;
-  console.log(bms_object)
   setBmsData(bms_object);
 });
 
 
 listen('state', (event) => {
-  console.log(event.windowLabel);
   setConfigurations((event.payload as State).configs);
   setActiveConfig((event.payload as State).activeConfig);
 });

--- a/gui/src/avi/fc-sensors/fc-sensors.tsx
+++ b/gui/src/avi/fc-sensors/fc-sensors.tsx
@@ -27,13 +27,10 @@ const [fcSensorsData, setFcSensorsData] = createSignal({
 listen('device_update', (event) => {
   // get sensor data
   const fc_sensors_object = (event.payload as StreamState).fc_sensors;
-  console.log(event.payload);
-  console.log(fc_sensors_object)
   setFcSensorsData(fc_sensors_object);
 });
 
 listen('state', (event) => {
-  console.log(event.windowLabel);
   setConfigurations((event.payload as State).configs);
   setActiveConfig((event.payload as State).activeConfig);
 });

--- a/gui/src/avi/reco/reco.tsx
+++ b/gui/src/avi/reco/reco.tsx
@@ -85,9 +85,6 @@ listen('device_update', (event) => {
   // get sensor data
   const reco_object = (event.payload as StreamState).reco;
   const gps_object = (event.payload as StreamState).gps;
-  console.log(event.payload);
-  console.log(reco_object);
-  console.log(gps_object);
   if (reco_object[0] != undefined) {
     setRecoDataA(reco_object[0]);
   }

--- a/gui/src/plotter/Chart.tsx
+++ b/gui/src/plotter/Chart.tsx
@@ -105,7 +105,6 @@ const ChartComponent: Component<{ id: string, index: number }> = (props) => {
           if (dataset.data.length > timespan * refreshFrequency) {
             dataset.data.shift();
           }
-          console.log('dataset ' + dataset.label + ' ' + dataset.data.length);
         });
     };
   const config: ChartConfiguration = {

--- a/gui/src/plotter/PlotterView.tsx
+++ b/gui/src/plotter/PlotterView.tsx
@@ -148,7 +148,6 @@ listen('state', (event) => {
         a.text_id.localeCompare(b.text_id),
       ),
     );
-    console.log(newMappings);
 });
 
 invoke('initialize_state', {window: appWindow});

--- a/gui/src/sensors/Sensors.tsx
+++ b/gui/src/sensors/Sensors.tsx
@@ -26,7 +26,6 @@ listen('device_update', (event) => {
   const sensor_object = (event.payload as StreamState).sensor_readings;
   var devices = Object.keys(sensor_object).map((key) => [key, sensor_object[key as keyof typeof sensor_object] as StreamSensor]);
   // update data
-  console.log(devices);
   devices.forEach((device) => {
     var index = sensors().findIndex(item => (item.name === device[0] as string));
     if (index === -1) {
@@ -46,7 +45,6 @@ listen('state', (event) => {
   setServerIp((event.payload as State).serverIp);
   setSensCalibrations((event.payload as State).calibrations);
   //console.log(activeConfig());
-  console.log(configurations() as Config[]);
   var activeconfmappings = (configurations() as Config[]).filter((conf) => {return conf.id == activeConfig() as string})[0];
   var deviceOptions = new Array;
   //console.log(activeconfmappings);

--- a/gui/src/system/SystemPages.tsx
+++ b/gui/src/system/SystemPages.tsx
@@ -107,9 +107,6 @@ listen('state', (event) => {
   setSequences((event.payload as State).sequences);
   setAbortStages((event.payload as State).abortStages);
   setActiveAbortStage((event.payload as State).activeAbortStage);
-  console.log('from listener: ', configurations());
-  console.log('sequences from listener:', sequences());
-  console.log('abortStages from listener:', abortStages());
 });
 invoke('initialize_state', {window: appWindow});
 
@@ -620,7 +617,6 @@ function loadConfigEntries(index: number) {
 const EditConfigView: Component<{index: number}> = (props) => {
   var index = props.index;
   loadConfigEntries(index);
-  console.log(editableEntries);
   return <div style={{width: '100%'}}>
     <div class="add-config-section">
       <div class="add-config-setup">
@@ -787,8 +783,6 @@ const ConfigView: Component = (props) => {
         </div>
 
         {(() => {
-          console.log('some display set');
-          console.log(configFocusIndex());
           if (subConfigDisplay() == 'add') {
             return <AddConfigView />;
           } else if (subConfigDisplay() == 'view') {
@@ -1247,7 +1241,6 @@ function loadAbortStageEntries(index: number) {
 const EditAbortStageView: Component<{index: number}> = (props) => {
   var index = props.index;
   loadAbortStageEntries(index);
-  console.log(editableAbortStageEntries);
   return <div style={{width: '100%'}}>
     <div class="add-config-section">
       <div class="add-config-setup">
@@ -1399,8 +1392,6 @@ const AbortStageView: Component = (props) => {
         </div>
 
         {(() => {
-          console.log('some display set');
-          console.log(abortStageFocusIndex());
           if (subAbortStageDisplay() == 'add') {
             return <AddAbortStageView />;
           } else if (subAbortStageDisplay() == 'view') {

--- a/gui/src/task-bar/Body.tsx
+++ b/gui/src/task-bar/Body.tsx
@@ -36,8 +36,6 @@ listen('device_update', (event) => {
       : existing?.lastChangedAt ?? now;
 
     const lastChange = (now - lastChangedAt); // in ms
-    console.log("last changed at");
-    console.log(lastChange);
 
     const devConnected = newLastUpdate < DISCONNECT_THRESH && lastChange < DISCONNECT_THRESH && isConnected();
 

--- a/gui/src/valves/Valves.tsx
+++ b/gui/src/valves/Valves.tsx
@@ -20,12 +20,10 @@ export const [valves, setValves] = createSignal(new Array<Valve>);
 listen('device_update', (event) => {
   const valve_object = (event.payload as StreamState).valve_states;
   var valveDevices = Object.keys(valve_object).map((key) => [key, valve_object[key as keyof typeof valve_object]]);
-  console.log(valveDevices);
   // updating all valves
   valveDevices.forEach(async (device) => {
     var index = valves().findIndex(item => (item.name === device[0] as string));
     var new_valves = [...valves()];
-    console.log(device[1]);
     var valveStates = (device[1] as unknown as object);
     new_valves[index].commanded = valveStates['commanded' as keyof typeof valveStates];
     new_valves[index].actual = valveStates['actual' as keyof typeof valveStates];
@@ -35,16 +33,12 @@ listen('device_update', (event) => {
 
 
 listen('state', (event) => {
-  console.log(event.windowLabel);
   setConfigurations((event.payload as State).configs);
   setActiveConfig((event.payload as State).activeConfig);
   setSequences((event.payload as State).sequences);
-  console.log(activeConfig());
-  console.log(configurations() as Config[]);
   var activeconfmappings = (configurations() as Config[]).filter((conf) => {return conf.id == activeConfig() as string})[0];
   var vlvs = new Array;
   var deviceOptions = new Array;
-  console.log(activeconfmappings);
   for (const mapping of activeconfmappings.mappings) {
     if (mapping.sensor_type === 'valve') {
       deviceOptions.push(mapping);

--- a/utility/src/main.rs
+++ b/utility/src/main.rs
@@ -141,35 +141,54 @@ fn read_postcard_file(path: &PathBuf) -> Result<Vec<Entry>, Box<dyn std::error::
             Err(e) => return Err(e.into()),
         }
         
-        // Try to deserialize based on detected file type, or try both if unknown
+        // Try to deserialize based on detected file type, or try both if unknown.
+        // After the first postcard error, stop as the length-prefix framing is no longer
+        // trustworthy once bytes are misaligned or truncated inside a record.
         let entry = match file_type {
-            Some(true) => {
-                // Known to be VehicleState
-                let entry: TimestampedVehicleState = from_bytes(&data)?;
-                Entry::VehicleState(entry)
-            }
-            Some(false) => {
-                // Known to be Imu
-                let entry: TimestampedImu = from_bytes(&data)?;
-                Entry::Imu(entry)
-            }
-            None => {
-                // Unknown type - try VehicleState first
-                match from_bytes::<TimestampedVehicleState>(&data) {
+            Some(true) => match from_bytes::<TimestampedVehicleState>(&data) {
+                Ok(entry) => Entry::VehicleState(entry),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: postcard deserialize failed after {} complete entries ({e}). \
+                         Treating the remainder of the file as corrupted.",
+                        entries.len()
+                    );
+                    break;
+                }
+            },
+            Some(false) => match from_bytes::<TimestampedImu>(&data) {
+                Ok(entry) => Entry::Imu(entry),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: postcard deserialize failed after {} complete entries ({e}). \
+                         Treating the remainder of the file as corrupted.",
+                        entries.len()
+                    );
+                    break;
+                }
+            },
+            None => match from_bytes::<TimestampedVehicleState>(&data) {
+                Ok(entry) => {
+                    file_type = Some(true);
+                    Entry::VehicleState(entry)
+                }
+                Err(_) => match from_bytes::<TimestampedImu>(&data) {
                     Ok(entry) => {
-                        file_type = Some(true);
-                        Entry::VehicleState(entry)
-                    }
-                    Err(_) => {
-                        // Try Imu
-                        let entry: TimestampedImu = from_bytes(&data)?;
                         file_type = Some(false);
                         Entry::Imu(entry)
                     }
-                }
-            }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: could not deserialize entry as VehicleState or Imu \
+                             after {} complete entries ({e}). Treating the remainder as corrupted.",
+                            entries.len()
+                        );
+                        break;
+                    }
+                },
+            },
         };
-        
+
         entries.push(entry);
     }
     


### PR DESCRIPTION
Added additional functionality to the Flight Computer's file logger to enable writing data to multiple directories simultaneously. Also allowed an optional file sync mechanic to ensure data is written to disk every time we flush the log a certain number of times.

**TODO** Modify `LoggerConfig::from_cli_commands()` and `default_log_dir()` to include the Blackbox log directories once we nail down specific directory mount locations.