### PR TITLE
[AVI-309] Add ci support that triggers on pr status change

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-D", "warnings"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-D", "warnings"]

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -63,8 +63,7 @@ jobs:
 
       - name: Build common
         run: |
-          cargo build -p common --release
-          cargo build -p common -F sequences --release
+          cargo build -p common --all-features --release
 
       - name: Build servo
         run: cargo build -p servo --release

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -25,8 +25,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libsoup2.4-dev \
+            libwebkit2gtk-4.0-dev \
             build-essential \
             curl \
             wget \

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Build ads114s06
         run: cargo build -p ads114s06 --release
 
+      - name: Build ads124s06
+        run: cargo build -p ads124s06 --release
+
       - name: Build imu
         run: cargo build -p imu --release
 
@@ -91,6 +94,9 @@ jobs:
 
       - name: Build reco
         run: cargo build -p reco --release
+
+      - name: Build utility
+        run: cargo build -p postcard-to-csv --release
 
       - name: Build GUI
         working-directory: ./gui

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -1,0 +1,101 @@
+name: PR Build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install repository Rust toolchain
+        run: rustup show
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Install GUI system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21
+          cache: npm
+          cache-dependency-path: gui/package-lock.json
+
+      - name: Install Yarn
+        run: sudo npm install -g yarn
+
+      - name: Install GUI dependencies
+        working-directory: ./gui
+        run: |
+          npm install
+          npm run install:platform
+
+      - name: Build flight computer
+        run: cargo build -p flight-computer --release
+
+      - name: Build SAM
+        working-directory: ./sam
+        run: cross build --target armv7-unknown-linux-gnueabihf
+
+      - name: Build BMS
+        working-directory: ./bms
+        run: cross build --target armv7-unknown-linux-gnueabihf
+
+      - name: Build common
+        run: |
+          cargo build -p common --release
+          cargo build -p common -F sequences --release
+
+      - name: Build servo
+        run: cargo build -p servo --release
+
+      - name: Build utility
+        run: cargo build -p utility --release
+
+      - name: Build ads114s06
+        run: cargo build -p ads114s06 --release
+
+      - name: Build imu
+        run: cargo build -p imu --release
+
+      - name: Build imu-testing
+        run: cargo build -p imu-testing --release
+
+      - name: Build lis2mdl
+        run: cargo build -p lis2mdl --release
+
+      - name: Build magnetometer-testing
+        run: cargo build -p magnetometer-testing --release
+
+      - name: Build ms5611
+        run: cargo build -p ms5611 --release
+
+      - name: Build zedf9p04b
+        run: cargo build -p zedf9p04b --release
+
+      - name: Build reco
+        run: cargo build -p reco --release
+
+      - name: Build GUI
+        working-directory: ./gui
+        run: npm run tauri build

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -55,11 +55,11 @@ jobs:
 
       - name: Build SAM
         working-directory: ./sam
-        run: cross build --target armv7-unknown-linux-gnueabihf
+        run: cross build --target armv7-unknown-linux-gnueabihf --release
 
       - name: Build BMS
         working-directory: ./bms
-        run: cross build --target armv7-unknown-linux-gnueabihf
+        run: cross build --target armv7-unknown-linux-gnueabihf --release
 
       - name: Build common
         run: |

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-	    libsoup2.4-dev \
+            libsoup2.4-dev \
             build-essential \
             curl \
             wget \

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -26,6 +26,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
+	    libsoup2.4-dev \
             build-essential \
             curl \
             wget \

--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -69,9 +69,6 @@ jobs:
       - name: Build servo
         run: cargo build -p servo --release
 
-      - name: Build utility
-        run: cargo build -p utility --release
-
       - name: Build ads114s06
         run: cargo build -p ads114s06 --release
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,30 @@
+name: Pre-Commit
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # rust-toolchain.toml already does this, so just show the toolchain
+      - name: Install repository Rust toolchain
+        run: rustup show
+
+      # rustfmt.toml uses nightly-only formatting options
+      - name: Install nightly rustfmt
+        run: rustup toolchain install nightly --component rustfmt
+
+      - name: Install pre-commit
+        run: python3 -m pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files


### PR DESCRIPTION
## Overview

Create github CI actions that are triggered on every change to a PR (ie. PR creation, changes to the branch during review / further development, etc).

There are two actions, one that runs the pre-commit config that was introduced in [this pr](https://github.com/gt-space/luna/pull/150), and another that runs a build of all projects in this repository (using their appropriate build commands, ie. using cross for SAM / BMS).

## Verification Evidence

CI passes with the two added actions.