### PR TITLE
[AVI-311] Fix imu and mag testing build warnings

### DIFF
--- a/firmware/imu-testing/src/main.rs
+++ b/firmware/imu-testing/src/main.rs
@@ -1,12 +1,7 @@
-use std::{
-    env,
-    sync::Mutex,
-    thread::sleep,
-    time::{Duration, SystemTime},
-};
+use std::{env, thread::sleep, time::Duration};
 
-use common::comm::gpio::{Gpio, Pin, PinMode, PinMode::*, PinValue::*};
-use imu::{AdisIMUDriver, DeltaReadData, GenericData, GyroReadData};
+use common::comm::gpio::{Gpio, PinMode::*, PinValue::*};
+use imu::AdisIMUDriver;
 use once_cell::sync::Lazy;
 use spidev::Spidev;
 
@@ -16,7 +11,7 @@ const MAG_CS_PIN_LOC: [usize; 2] = [1, 14];
 const IMU_DR_PIN_LOC: [usize; 2] = [2, 17];
 const IMU_NRESET_PIN_LOC: [usize; 2] = [2, 25];
 
-pub static GPIO_CONTROLLERS: Lazy<Vec<Gpio>> = Lazy::new(|| open_controllers());
+pub static GPIO_CONTROLLERS: Lazy<Vec<Gpio>> = Lazy::new(open_controllers);
 
 // controller = floor(GPIO#/32)
 // pin = remainder

--- a/firmware/magnetometer-testing/src/main.rs
+++ b/firmware/magnetometer-testing/src/main.rs
@@ -8,7 +8,7 @@ const IMU_CS_PIN_LOC: [usize; 2] = [0, 5];
 const BAR_CS_PIN_LOC: [usize; 2] = [0, 12];
 const MAG_CS_PIN_LOC: [usize; 2] = [0, 13];
 
-pub static GPIO_CONTROLLERS: Lazy<Vec<Gpio>> = Lazy::new(|| open_controllers());
+pub static GPIO_CONTROLLERS: Lazy<Vec<Gpio>> = Lazy::new(open_controllers);
 
 pub fn open_controllers() -> Vec<Gpio> {
     (0..=3).map(Gpio::open_controller).collect()


### PR DESCRIPTION
## Overview

Manually fix build warnings in the `imu-testing` and `magnetometer-testing` projects that could not be fixed by rustfmt.

## Verification Evidence

The latest CI run in [this PR](https://github.com/gt-space/luna/pull/163) passes.