### PR TITLE
[AVI-313] Fix gps build warnings

### DIFF
--- a/firmware/zedf9p04b/examples/config_checker.rs
+++ b/firmware/zedf9p04b/examples/config_checker.rs
@@ -48,11 +48,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         Ok(ubx_packet) => {
                             found_valid_packet = true;
                             // Extract Proto23 variant from UbxPacket
-                            if let UbxPacket::Proto23(packet) = ubx_packet {
-                                if let PacketRef::MonVer(mon_ver) = packet {
-                                    println!("   ✓ Module version: {}", mon_ver.software_version());
-                                    println!("   ✓ Hardware: {}", mon_ver.hardware_version());
-                                }
+                            let UbxPacket::Proto23(packet) = ubx_packet;
+                            if let PacketRef::MonVer(mon_ver) = packet {
+                                println!("   ✓ Module version: {}", mon_ver.software_version());
+                                println!("   ✓ Hardware: {}", mon_ver.hardware_version());
                             }
                         }
                         Err(_) => {
@@ -66,7 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             } else {
                 // Check if it's NMEA text
-                let has_nmea = buf.iter().any(|&b| b == b'$');
+                let has_nmea = buf.contains(&b'$');
                 if has_nmea {
                     println!("   ✗ Receiving NMEA text format (should be UBX)");
                     println!("   → Run 'configure_ubx' to fix this");
@@ -90,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut data_samples = 0;
     let mut non_ff_samples = 0;
 
-    for i in 1..=10 {
+    for _ in 1..=10 {
         let mut buf = vec![0u8; 64];
         match i2c.read(&mut buf) {
             Ok(_) => {

--- a/firmware/zedf9p04b/examples/satellite_monitor.rs
+++ b/firmware/zedf9p04b/examples/satellite_monitor.rs
@@ -43,56 +43,50 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     match result {
                         Ok(ubx_packet) => {
                             // Extract Proto23 variant from UbxPacket
-                            if let UbxPacket::Proto23(packet) = ubx_packet {
-                                if let PacketRef::NavSat(nav_sat) = packet {
-                                    found_sat_data = true;
-                                    let sat_count = nav_sat.num_svs();
+                            let UbxPacket::Proto23(packet) = ubx_packet;
+                            if let PacketRef::NavSat(nav_sat) = packet {
+                                found_sat_data = true;
+                                let sat_count = nav_sat.num_svs();
 
-                                    if sat_count != last_sat_count {
-                                        println!("Satellites visible: {}", sat_count);
-                                        last_sat_count = sat_count;
-                                    }
+                                if sat_count != last_sat_count {
+                                    println!("Satellites visible: {}", sat_count);
+                                    last_sat_count = sat_count;
+                                }
 
-                                    if sat_count > 0 {
-                                        println!("  Signal details:");
+                                if sat_count > 0 {
+                                    println!("  Signal details:");
 
-                                        for sv in nav_sat.svs() {
-                                            let constellation = match sv.gnss_id() {
-                                                0 => "GPS",
-                                                1 => "SBAS",
-                                                2 => "GAL",
-                                                3 => "BDS",
-                                                6 => "GLO",
-                                                5 => "QZSS",
-                                                _ => "Unknown",
-                                            };
+                                    for sv in nav_sat.svs() {
+                                        let constellation = match sv.gnss_id() {
+                                            0 => "GPS",
+                                            1 => "SBAS",
+                                            2 => "GAL",
+                                            3 => "BDS",
+                                            6 => "GLO",
+                                            5 => "QZSS",
+                                            _ => "Unknown",
+                                        };
 
-                                            let signal_strength = sv.cno();
-                                            let elevation = sv.elev();
-                                            let azimuth = sv.azim();
+                                        let signal_strength = sv.cno();
+                                        let elevation = sv.elev();
+                                        let azimuth = sv.azim();
 
-                                            if signal_strength > 0 {
-                                                println!(
-                                                    "    {} SV{}: {}dB, elev:{}°, azim:{}°",
-                                                    constellation,
-                                                    sv.sv_id(),
-                                                    signal_strength,
-                                                    elevation,
-                                                    azimuth
-                                                );
-                                            }
-                                        }
-
-                                        println!();
-                                    } else {
-                                        if attempts % 10 == 0 {
+                                        if signal_strength > 0 {
                                             println!(
-                                                "  No satellites visible (attempt {})",
-                                                attempts
+                                                "    {} SV{}: {}dB, elev:{}°, azim:{}°",
+                                                constellation,
+                                                sv.sv_id(),
+                                                signal_strength,
+                                                elevation,
+                                                azimuth
                                             );
-                                            println!("  Check antenna connection and sky view");
                                         }
                                     }
+
+                                    println!();
+                                } else if attempts % 10 == 0 {
+                                    println!("  No satellites visible (attempt {})", attempts);
+                                    println!("  Check antenna connection and sky view");
                                 }
                             }
                         }

--- a/firmware/zedf9p04b/examples/simple_i2c_test.rs
+++ b/firmware/zedf9p04b/examples/simple_i2c_test.rs
@@ -59,16 +59,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             Ok(ubx_packet) => {
                                 found_response = true;
                                 // Extract Proto23 variant from UbxPacket
-                                if let UbxPacket::Proto23(packet) = ubx_packet {
-                                    println!("\n✓ Found packet: {:?}\n", packet);
+                                let UbxPacket::Proto23(packet) = ubx_packet;
+                                println!("\n✓ Found packet: {:?}\n", packet);
 
-                                    if let PacketRef::MonVer(mon_ver) = packet {
-                                        println!("SW version: {}", mon_ver.software_version());
-                                        println!("HW version: {}", mon_ver.hardware_version());
-                                    }
+                                if let PacketRef::MonVer(mon_ver) = packet {
+                                    println!("SW version: {}", mon_ver.software_version());
+                                    println!("HW version: {}", mon_ver.hardware_version());
                                 }
                             }
-                            Err(e) => {
+                            Err(_e) => {
                                 // Malformed packet, that's ok
                             }
                         }

--- a/firmware/zedf9p04b/examples/simple_satellite_test.rs
+++ b/firmware/zedf9p04b/examples/simple_satellite_test.rs
@@ -48,37 +48,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             found_any_packet = true;
 
                             // Extract Proto23 variant from UbxPacket
-                            if let UbxPacket::Proto23(packet) = ubx_packet {
-                                match packet {
-                                    PacketRef::NavSat(nav_sat) => {
-                                        let sat_count = nav_sat.num_svs();
-                                        println!("✓ NAV-SAT: {} satellites visible", sat_count);
+                            let UbxPacket::Proto23(packet) = ubx_packet;
+                            match packet {
+                                PacketRef::NavSat(nav_sat) => {
+                                    let sat_count = nav_sat.num_svs();
+                                    println!("✓ NAV-SAT: {} satellites visible", sat_count);
 
-                                        if sat_count > 0 {
-                                            for sv in nav_sat.svs() {
-                                                let signal = sv.cno();
-                                                if signal > 0 {
-                                                    println!(
-                                                        "  SV{}: {}dB signal",
-                                                        sv.sv_id(),
-                                                        signal
-                                                    );
-                                                }
+                                    if sat_count > 0 {
+                                        for sv in nav_sat.svs() {
+                                            let signal = sv.cno();
+                                            if signal > 0 {
+                                                println!("  SV{}: {}dB signal", sv.sv_id(), signal);
                                             }
-                                        } else {
-                                            println!("  → No satellites visible (antenna issue?)");
                                         }
+                                    } else {
+                                        println!("  → No satellites visible (antenna issue?)");
                                     }
-                                    PacketRef::NavStatus(nav_status) => {
-                                        println!(
-                                            "✓ NAV-STATUS: Fix type = {:?}",
-                                            nav_status.fix_type()
-                                        );
-                                        println!("  Flags: {:?}", nav_status.flags());
-                                    }
-                                    _ => {
-                                        println!("✓ Other packet: {:?}", packet);
-                                    }
+                                }
+                                PacketRef::NavStatus(nav_status) => {
+                                    println!(
+                                        "✓ NAV-STATUS: Fix type = {:?}",
+                                        nav_status.fix_type()
+                                    );
+                                    println!("  Flags: {:?}", nav_status.flags());
+                                }
+                                _ => {
+                                    println!("✓ Other packet: {:?}", packet);
                                 }
                             }
                         }
@@ -88,10 +83,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                if !found_any_packet {
-                    if attempt % 5 == 0 {
-                        println!("Attempt {}: No valid packets received", attempt);
-                    }
+                if !found_any_packet && attempt % 5 == 0 {
+                    println!("Attempt {}: No valid packets received", attempt);
                 }
             }
             Err(_) => {

--- a/firmware/zedf9p04b/examples/verify_ubx.rs
+++ b/firmware/zedf9p04b/examples/verify_ubx.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         match i2c.read(&mut buf) {
             Ok(_) => {
                 // Check for UBX sync bytes
-                if buf.iter().any(|&b| b == 0xB5) {
+                if buf.contains(&0xB5) {
                     println!("Attempt {}: Found UBX sync byte (0xB5)!", attempt);
 
                     // Try to parse
@@ -42,26 +42,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 println!("\n✓ SUCCESS! Received valid UBX packet:");
 
                                 // Extract Proto23 variant from UbxPacket
-                                if let UbxPacket::Proto23(packet) = ubx_packet {
-                                    match packet {
-                                        PacketRef::MonVer(mon_ver) => {
-                                            println!("  Type: MON-VER");
-                                            println!(
-                                                "  SW version: {}",
-                                                mon_ver.software_version()
-                                            );
-                                            println!(
-                                                "  HW version: {}",
-                                                mon_ver.hardware_version()
-                                            );
-                                            println!(
-                                                "  Extensions: {:?}",
-                                                mon_ver.extension().collect::<Vec<&str>>()
-                                            );
-                                        }
-                                        _ => {
-                                            println!("  Type: {:?}", packet);
-                                        }
+                                let UbxPacket::Proto23(packet) = ubx_packet;
+                                match packet {
+                                    PacketRef::MonVer(mon_ver) => {
+                                        println!("  Type: MON-VER");
+                                        println!("  SW version: {}", mon_ver.software_version());
+                                        println!("  HW version: {}", mon_ver.hardware_version());
+                                        println!(
+                                            "  Extensions: {:?}",
+                                            mon_ver.extension().collect::<Vec<&str>>()
+                                        );
+                                    }
+                                    _ => {
+                                        println!("  Type: {:?}", packet);
                                     }
                                 }
                             }
@@ -78,14 +71,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 } else {
                     // Check if it's still NMEA
-                    let has_nmea = buf.iter().any(|&b| b == b'$');
+                    let has_nmea = buf.contains(&b'$');
                     let has_data = buf.iter().filter(|&&b| b != 0xFF && b != 0x00).count() > 10;
 
                     if has_nmea {
                         println!("Attempt {}: Still receiving NMEA data!", attempt);
                         print!("  Sample: ");
                         for &byte in buf.iter().take(40).filter(|&&b| b != 0xFF) {
-                            if byte >= 32 && byte <= 126 {
+                            if (32..=126).contains(&byte) {
                                 print!("{}", byte as char);
                             } else {
                                 print!(".");

--- a/firmware/zedf9p04b/src/lib.rs
+++ b/firmware/zedf9p04b/src/lib.rs
@@ -305,7 +305,7 @@ impl GPS {
 
                         // Always record the reported number of satellites for this
                         // solution.
-                        pvt.num_sats = Some(sol.num_satellites() as u8);
+                        pvt.num_sats = Some(sol.num_satellites());
                     }
                     _ => {
                         // Some other packet
@@ -392,7 +392,7 @@ impl GPS {
                     }
 
                     // Record the reported number of satellites for this solution.
-                    pvt.num_sats = Some(sol.num_satellites() as u8);
+                    pvt.num_sats = Some(sol.num_satellites());
                 }
                 _ => {
                     // Some other packet, ignore
@@ -462,13 +462,9 @@ impl GPS {
             match it.next() {
                 Some(Ok(ubx_packet)) => {
                     got_good_packet = true;
-                    // Convert UbxPacket to PacketRef by extracting the Proto23 variant
-                    // We only support Proto23, so ignore other protocol versions
-                    if let UbxPacket::Proto23(packet_ref) = ubx_packet {
-                        cb(packet_ref);
-                    }
-                    // Note: Other protocol versions (Proto14, Proto27, Proto31)
-                    // are ignored
+                    // Ublox 0.7 default features only support and compile in Proto23
+                    let UbxPacket::Proto23(packet_ref) = ubx_packet;
+                    cb(packet_ref);
                 }
                 Some(Err(_)) => {
                     // Malformed packet, ignore


### PR DESCRIPTION
## Overview

Manually fix build warnings in the GPS project that could not be fixed by rustfmt. 

## Verification Evidence

The latest CI run in [this PR](https://github.com/gt-space/luna/pull/163) passes.