### PR TITLE
[AVI-316] Add config.toml that makes build warnings errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-D", "warnings"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,10 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
-      - id: cargo-check
-        name: cargo check
-        description: Check code compiles using cargo
-        entry: cargo check --all-targets --all-features
+      - id: cargo-clippy
+        name: cargo clippy
+        description: Check code compiles using cargo and run clippy linter
+        entry: cargo clippy --all-targets --all-features
         language: system
         types: [rust]
         pass_filenames: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,8 @@
 	"editor.tabSize": 2,
 	"gitlens.codeLens.enabled": false,
 	"rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.allTargets": true,
+  "rust-analyzer.check.features": "all",
 	"rust-analyzer.checkOnSave": true,
 	"rust-analyzer.lens.enable": false,
 	"rust-analyzer.rustfmt.extraArgs": [

--- a/common/src/comm.rs
+++ b/common/src/comm.rs
@@ -1,5 +1,7 @@
 use core::fmt::Debug;
-use std::{any::Any, collections::HashMap, fmt, hash::Hash, io, time::Duration};
+#[cfg(feature = "gpio")]
+use std::{any::Any, io};
+use std::{collections::HashMap, fmt, hash::Hash, time::Duration};
 
 use bytecheck;
 use compaq::{compress, Compress};

--- a/firmware/reco/examples/basic_test.rs
+++ b/firmware/reco/examples/basic_test.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 1: Send "launched" message
     println!(
-        "\n--- Test 1: Sending 'launched' message (opcode {:#02X}) ---",
+        "\n--- Test 1: Sending 'launched' message (opcode {:#X}) ---",
         opcode::LAUNCHED
     );
     match reco.send_launched() {
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 2: Send GPS data
     println!(
-        "\n--- Test 2: Sending GPS data (opcode {:#02X}) ---",
+        "\n--- Test 2: Sending GPS data (opcode {:#X}) ---",
         opcode::GPS_DATA
     );
     let gps_data = FcGpsBody {
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 3: Send EKF-initialization command
     println!(
-        "\n--- Test 3: Sending EKF init (opcode {:#02X}) ---",
+        "\n--- Test 3: Sending EKF init (opcode {:#X}) ---",
         opcode::INIT_EKF
     );
     match reco.send_init_ekf() {

--- a/flight2/src/device.rs
+++ b/flight2/src/device.rs
@@ -3,7 +3,6 @@ use std::{
     fmt, io,
     net::{IpAddr, SocketAddr, UdpSocket},
     ops::Deref,
-    sync::mpsc,
     time::{Duration, Instant},
 };
 
@@ -13,7 +12,7 @@ use common::comm::{
     reco::{
         GuiCommand as SharedRecoCommand, SequenceCommand as RecoSequenceCommand, TargetedGuiCommand,
     },
-    sam::{SamControlMessage, Unit},
+    sam::SamControlMessage,
     AbortStage, AbortStageConfig, CompositeValveState, GpsState, Measurement, NodeMapping,
     RecoState, SensorType, Statistics, ValveAction, ValveState, VehicleState,
 };
@@ -57,18 +56,13 @@ impl Device {
         self.last_recieved = Instant::now();
     }
 
-    pub(crate) fn send_heartbeat(
-        &self,
-        socket: &UdpSocket,
-        devices: &Devices,
-        mappings: &Mappings,
-    ) -> Result<()> {
+    pub(crate) fn send_heartbeat(&self, socket: &UdpSocket) -> Result<()> {
         let mut buf: [u8; 1024] = [0; 1024];
         let serialized = postcard::to_slice(&DataMessage::FlightHeartbeat, &mut buf)
-            .map_err(|e| Error::SerializationFailed(e))?;
+            .map_err(Error::SerializationFailed)?;
         socket
             .send_to(serialized, self.address)
-            .map_err(|e| Error::TransportFailed(e))?;
+            .map_err(Error::TransportFailed)?;
 
         Ok(())
     }
@@ -77,38 +71,11 @@ impl Device {
         Instant::now().duration_since(self.last_recieved) > TIME_TO_LIVE
     }
 
-    /// Sends a message on a socket to a board with id `destination`
-    fn serialize_and_send<T: serde::ser::Serialize>(
-        &self,
-        socket: &UdpSocket,
-        destination: &str,
-        message: &T,
-        devices: &Devices,
-    ) -> std::result::Result<(), String> {
-        let mut buf: [u8; 1024] = [0; 1024];
-
-        let Some(device) = devices.iter().find(|d| d.id == *destination) else {
-            return Err(
-                "Tried to sent a message to a board that hasn't been connected yet.".to_string(),
-            );
-        };
-
-        if let Err(e) = postcard::to_slice::<T>(message, &mut buf) {
-            return Err(format!("Couldn't serialize message: {e}"));
-        };
-
-        if let Err(e) = device.send(socket, &buf) {
-            return Err(format!("Couldn't send message to {destination}: {e}"));
-        };
-
-        return Ok(());
-    }
-
     /// Sends data to the device via a given socket.
     pub(crate) fn send(&self, socket: &UdpSocket, buf: &[u8]) -> Result<()> {
         socket
             .send_to(buf, (self.address.ip(), DEVICE_COMMAND_PORT))
-            .map_err(|e| Error::TransportFailed(e))?;
+            .map_err(Error::TransportFailed)?;
         Ok(())
     }
 
@@ -175,16 +142,16 @@ impl Devices {
     /// Overwriting a device replaces all of its associated data, as if it were
     /// connecting for the first time. Returns a reference to the newly inserted
     /// device and the overwritten device, if it existed.
-    pub(crate) fn register_device(&mut self, id: &String, address: SocketAddr) -> Option<Device> {
-        let device = Device::new(id.clone(), address);
+    pub(crate) fn register_device(&mut self, id: &str, address: SocketAddr) -> Option<Device> {
+        let device = Device::new(id.to_string(), address);
 
         if let Some(copy) = self.devices.iter_mut().find(|d| d.id == device.id) {
             let old = copy.clone();
             *copy = device;
-            return Some(old);
+            Some(old)
         } else {
             self.devices.push(device);
-            return None;
+            None
         }
     }
 
@@ -339,17 +306,16 @@ impl Devices {
             return Err(format!("Couldn't send message to {destination}: {e}"));
         };
 
-        return Ok(());
+        Ok(())
     }
 
-    ///
+    /// Send `commands` to the SAMs.
     pub(crate) fn send_sam_commands(
         &mut self,
         socket: &UdpSocket,
         mappings: &Mappings,
         commands: Vec<SequenceDomainCommand>,
         abort_stages: &mut AbortStages,
-        sequences: &mut Sequences,
         gps_handle: Option<&GpsHandle>,
     ) -> bool {
         let mut should_abort = false;
@@ -572,11 +538,11 @@ impl Devices {
             // append our determination of whether to power this valve to its SAM
             // board vector
             board_valves
-                .entry(board_id.clone().to_string())
-                .or_insert_with(Vec::new)
+                .entry(board_id.to_string())
+                .or_default()
                 .push(ValveAction {
                     channel_num: channel,
-                    powered: powered,
+                    powered,
                     timer: Duration::from_millis(valve_state_info.safing_timer as u64),
                 });
         }
@@ -607,7 +573,7 @@ impl Devices {
         // change the abort stage in vehicle state by looking through saved abort
         // stage configs. if name doesn't match up throw an error
         if let Some(stage) = abort_stages.iter().find(|m| m.name == stage_name) {
-            self.set_abort_stage(&stage);
+            self.set_abort_stage(stage);
         } else {
             eprintln!("Tried to set abort stage to {stage_name} but could not find the stage.");
             return;
@@ -667,7 +633,7 @@ impl Devices {
                 };
 
                 // send message to this sam board
-                if let Err(msg) = self.serialize_and_send(socket, &board_id, &command) {
+                if let Err(msg) = self.serialize_and_send(socket, board_id, &command) {
                     println!("{}", msg);
                 } else {
                     println!(
@@ -890,15 +856,15 @@ pub(crate) fn get_reco_rbf_values(samples: &[Option<RecoState>; 3]) -> [u8; 3] {
 pub(crate) fn handshake(address: &SocketAddr, socket: &UdpSocket) -> Result<()> {
     let mut buf: [u8; 1024] = [0; 1024];
     let serialized = postcard::to_slice(&DataMessage::Identity("flight-01".to_string()), &mut buf)
-        .map_err(|e| Error::SerializationFailed(e))?;
+        .map_err(Error::SerializationFailed)?;
     socket
         .send_to(serialized, address)
-        .map_err(|e| Error::TransportFailed(e))?;
+        .map_err(Error::TransportFailed)?;
     Ok(())
 }
 
 /// Gets the most recent UDP Commands
-pub(crate) fn receive(socket: &UdpSocket) -> Vec<(SocketAddr, DataMessage)> {
+pub(crate) fn receive(socket: &UdpSocket) -> Vec<(SocketAddr, DataMessage<'static>)> {
     let mut messages = Vec::new();
     let mut buf: [u8; 1024] = [0; 1024];
 

--- a/flight2/src/file_logger.rs
+++ b/flight2/src/file_logger.rs
@@ -90,31 +90,31 @@ fn default_log_dir() -> Vec<PathBuf> {
 /// Error types for file logger operations
 #[derive(Debug)]
 pub enum LoggerError {
-    IoError(std::io::Error),
-    SerializationError(postcard::Error),
-    ChannelSendError,
+    Io(std::io::Error),
+    Serialization(postcard::Error),
+    ChannelSend,
 }
 
 impl From<std::io::Error> for LoggerError {
     fn from(err: std::io::Error) -> Self {
-        LoggerError::IoError(err)
+        LoggerError::Io(err)
     }
 }
 
 impl From<postcard::Error> for LoggerError {
     fn from(err: postcard::Error) -> Self {
-        LoggerError::SerializationError(err)
+        LoggerError::Serialization(err)
     }
 }
 
 impl std::fmt::Display for LoggerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LoggerError::IoError(e) => write!(f, "IO error: {}", e),
-            LoggerError::SerializationError(e) => {
+            LoggerError::Io(e) => write!(f, "IO error: {}", e),
+            LoggerError::Serialization(e) => {
                 write!(f, "Serialization error: {}", e)
             }
-            LoggerError::ChannelSendError => {
+            LoggerError::ChannelSend => {
                 write!(f, "Failed to send to logging channel")
             }
         }
@@ -369,9 +369,9 @@ impl FileLogger {
             Err(TrySendError::Full(_)) => {
                 // Channel is full - drop message (expected under heavy load)
                 // Don't warn to avoid spamming stderr
-                Err(LoggerError::ChannelSendError)
+                Err(LoggerError::ChannelSend)
             }
-            Err(TrySendError::Disconnected(_)) => Err(LoggerError::ChannelSendError),
+            Err(TrySendError::Disconnected(_)) => Err(LoggerError::ChannelSend),
         }
     }
 
@@ -444,15 +444,19 @@ impl FileLogger {
     }
 
     /// Shutdown the logger gracefully, flushing all pending data
+    #[expect(
+        dead_code,
+        reason = "Not used currently, but should be used in the future"
+    )]
     pub fn shutdown(self) -> Result<(), LoggerError> {
         // Drop sender to signal shutdown
         drop(self.sender);
 
         // Wait for thread to finish
         if let Some(handle) = self.handle {
-            handle.join().map_err(|_| {
-                LoggerError::IoError(std::io::Error::other("Logger thread panicked"))
-            })?;
+            handle
+                .join()
+                .map_err(|_| LoggerError::Io(std::io::Error::other("Logger thread panicked")))?;
         }
 
         Ok(())

--- a/flight2/src/imu_logger.rs
+++ b/flight2/src/imu_logger.rs
@@ -219,17 +219,15 @@ impl FileLogger {
                 }
             }
 
-            if should_flush_timeout || should_flush_batch {
-                if !batch.is_empty() {
-                    Self::write_batch(
-                        &mut current_file,
-                        &mut current_file_path,
-                        &mut batch,
-                        &mut file_size,
-                        &config,
-                    );
-                    last_flush = Instant::now();
-                }
+            if (should_flush_timeout || should_flush_batch) && !batch.is_empty() {
+                Self::write_batch(
+                    &mut current_file,
+                    &mut current_file_path,
+                    &mut batch,
+                    &mut file_size,
+                    &config,
+                );
+                last_flush = Instant::now();
             }
 
             if file_size >= config.file_size_limit {
@@ -316,7 +314,7 @@ impl FileLogger {
             Ok(new_path) => {
                 *current_file_path = new_path;
                 *file_size = 0;
-                match Self::open_file(&current_file_path, config) {
+                match Self::open_file(current_file_path, config) {
                     Ok(file) => *current_file = Some(file),
                     Err(e) => eprintln!("Failed to open new log file: {}", e),
                 }
@@ -331,19 +329,20 @@ impl FileLogger {
     }
 
     fn open_file_path(config: &LoggerConfig) -> Result<PathBuf, LoggerError> {
-        Ok(create_log_file_path(&config.log_dir)?)
+        create_log_file_path(&config.log_dir)
     }
 
     /// Shutdown the logger gracefully, flushing all pending data
+    #[expect(
+        dead_code,
+        reason = "Not used currently, but should be used in the future"
+    )]
     pub fn shutdown(self) -> Result<(), LoggerError> {
         drop(self.sender);
 
         if let Some(handle) = self.handle {
             handle.join().map_err(|_| {
-                LoggerError::IoError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Logger thread panicked",
-                ))
+                LoggerError::IoError(std::io::Error::other("Logger thread panicked"))
             })?;
         }
 

--- a/flight2/src/main.rs
+++ b/flight2/src/main.rs
@@ -463,7 +463,7 @@ fn main() -> ! {
             }
 
             if need_to_send_heartbeat {
-                if let Err(e) = device.send_heartbeat(&socket, &devices, &mappings) {
+                if let Err(e) = device.send_heartbeat(&socket) {
                     println!(
             "There was an error in notifying board {} at IP {} that the FC is still connected: {e}",
             device.get_board_id(),
@@ -507,7 +507,6 @@ fn main() -> ! {
             &mappings,
             sam_commands,
             &mut abort_stages,
-            &mut sequences,
             worker_handles.gps(),
         );
 

--- a/flight2/src/sequence.rs
+++ b/flight2/src/sequence.rs
@@ -55,7 +55,7 @@ pub(crate) fn execute(mappings: &Mappings, sequence: &Sequence, sequences: &mut 
         }
     }
 
-    let process = match run(mappings, &sequence) {
+    let process = match run(mappings, sequence) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("Error in running python3: {e}");
@@ -85,7 +85,7 @@ pub(crate) fn kill(sequences: &mut Sequences, name: &String) -> io::Result<()> {
     sequence.kill()
 }
 
-pub(crate) fn pull_commands<'a>(socket: &UnixDatagram) -> Vec<SequenceDomainCommand> {
+pub(crate) fn pull_commands(socket: &UnixDatagram) -> Vec<SequenceDomainCommand> {
     let mut buf: [u8; 1024] = [0; 1024];
     let mut commands = Vec::new();
 

--- a/flight2/src/servo.rs
+++ b/flight2/src/servo.rs
@@ -2,7 +2,6 @@ use std::{
     fmt,
     io::{self, Read, Write},
     net::{SocketAddr, TcpStream, ToSocketAddrs, UdpSocket},
-    thread,
     time::Duration,
 };
 
@@ -15,7 +14,7 @@ use socket2::{Domain, Protocol, Socket, TcpKeepalive, Type};
 
 use crate::{device::Mappings, SERVO_DATA_PORT};
 
-pub const servo_keep_alive_delay: Duration = Duration::from_secs(1);
+pub const SERVO_KEEP_ALIVE_DELAY: Duration = Duration::from_secs(1);
 /// DSCP marker applied to radio telemetry packets so Servo can distinguish
 /// them from the uncompressed umbilical telemetry stream on the same UDP port.
 pub const RADIO_TELEMETRY_DSCP: u8 = 0x2E;
@@ -161,7 +160,7 @@ pub(crate) fn establish(
     }
 
     let mut prev_addr_exists = false;
-    if let Some(a) = prev_connected_servo_addr {
+    if prev_connected_servo_addr.is_some() {
         prev_addr_exists = true;
     }
 
@@ -171,26 +170,26 @@ pub(crate) fn establish(
         println!("Attempting connection with servo at {addr:?}...");
 
         match TcpStream::connect_timeout(addr, timeout) {
-            Ok(mut s) => {
+            Ok(s) => {
                 let socket = Socket::from(s);
                 socket
                     .set_keepalive(true)
-                    .map_err(|e| return ServoError::TransportFailed(e))?;
+                    .map_err(ServoError::TransportFailed)?;
                 let keep_alive: TcpKeepalive = TcpKeepalive::new()
-                    .with_time(servo_keep_alive_delay)
+                    .with_time(SERVO_KEEP_ALIVE_DELAY)
                     .with_interval(Duration::from_secs(1))
                     .with_retries(1);
 
                 socket
                     .set_tcp_keepalive(&keep_alive)
-                    .map_err(|e| return ServoError::TransportFailed(e))?;
+                    .map_err(ServoError::TransportFailed)?;
                 let mut stream: std::net::TcpStream = socket.into();
                 stream
                     .set_nodelay(true)
-                    .map_err(|e| ServoError::TransportFailed(e))?;
+                    .map_err(ServoError::TransportFailed)?;
                 stream
                     .set_nonblocking(true)
-                    .map_err(|e| ServoError::TransportFailed(e))?;
+                    .map_err(ServoError::TransportFailed)?;
 
                 if let Err(e) = stream.write_all(&identity) {
                     return Err(ServoError::TransportFailed(e));
@@ -208,36 +207,30 @@ pub(crate) fn establish(
             .collect();
         for i in 1..=chances {
             for addr in &resolved_addresses {
-                if !prev_addr_exists || prev_connected_servo_addr.map_or(false, |prev| addr == prev)
-                {
+                if !prev_addr_exists || (prev_connected_servo_addr == Some(addr)) {
                     println!("[{i}]: Attempting connection with servo at {addr:?}...");
 
                     match TcpStream::connect_timeout(addr, timeout) {
-                        Ok(mut s) => {
-                            //s.set_nodelay(true).map_err(|e|
-                            // ServoError::TransportFailed(e))?;
-                            // s.set_nonblocking(true).map_err(|e|
-                            // ServoError::TransportFailed(e))?;
-
+                        Ok(s) => {
                             let socket = Socket::from(s);
                             socket
                                 .set_keepalive(true)
-                                .map_err(|e| return ServoError::TransportFailed(e))?;
+                                .map_err(ServoError::TransportFailed)?;
                             let keep_alive: TcpKeepalive = TcpKeepalive::new()
-                                .with_time(servo_keep_alive_delay)
+                                .with_time(SERVO_KEEP_ALIVE_DELAY)
                                 .with_interval(Duration::from_secs(1))
                                 .with_retries(1);
 
                             socket
                                 .set_tcp_keepalive(&keep_alive)
-                                .map_err(|e| return ServoError::TransportFailed(e))?;
+                                .map_err(ServoError::TransportFailed)?;
                             let mut stream: std::net::TcpStream = socket.into();
                             stream
                                 .set_nodelay(true)
-                                .map_err(|e| ServoError::TransportFailed(e))?;
+                                .map_err(ServoError::TransportFailed)?;
                             stream
                                 .set_nonblocking(true)
-                                .map_err(|e| ServoError::TransportFailed(e))?;
+                                .map_err(ServoError::TransportFailed)?;
 
                             if let Err(e) = stream.write_all(&identity) {
                                 return Err(ServoError::TransportFailed(e));
@@ -262,7 +255,7 @@ pub(crate) fn pull(servo_stream: &mut TcpStream) -> Result<Option<FlightControlM
 
     while index < 2 {
         index += match servo_stream.read(&mut buffer[index..]) {
-            Ok(s) if s == 0 => return Err(ServoError::ServoDisconnected),
+            Ok(0) => return Err(ServoError::ServoDisconnected),
             Ok(s) => s,
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock && index == 0 => return Ok(None),
             Err(e) => return Err(ServoError::TransportFailed(e)),
@@ -275,7 +268,7 @@ pub(crate) fn pull(servo_stream: &mut TcpStream) -> Result<Option<FlightControlM
 
     while index < size as usize + 2 {
         index += match servo_stream.read(&mut buffer[index..]) {
-            Ok(s) if s == 0 => return Err(ServoError::ServoDisconnected),
+            Ok(0) => return Err(ServoError::ServoDisconnected),
             Ok(s) => s,
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => 0,
             Err(e) => return Err(ServoError::TransportFailed(e)),

--- a/gui/src-tauri/src/main.rs
+++ b/gui/src-tauri/src/main.rs
@@ -4,10 +4,10 @@
 )]
 
 use local_ip_address::local_ip;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 use tokio::net::UdpSocket;
 use futures::lock::Mutex;
-use tauri::{State, Manager, Window, window, WindowBuilder};
+use tauri::{State, Manager, Window};
 use state::{AppState,
   update_is_connected,
   update_server_ip,
@@ -33,7 +33,7 @@ mod state;
 async fn initialize_state(window: Window, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   println!("initializing state!");
   let inner_state = Arc::clone(&state);
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ =window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 

--- a/gui/src-tauri/src/state.rs
+++ b/gui/src-tauri/src/state.rs
@@ -1,15 +1,15 @@
 use std::{sync::Arc, collections::HashMap};
 use local_ip_address::local_ip;
 
-use tauri::{Window, State, Manager, App};
-use futures::{future::Map, lock::Mutex};
+use tauri::{Window, State, Manager};
+use futures::lock::Mutex;
 use crate::utilities::{Alert};
 
 #[tauri::command]
 pub async fn update_is_connected(window: Window, value: bool, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).isConnected = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -17,7 +17,7 @@ pub async fn update_is_connected(window: Window, value: bool, state: State<'_, A
 pub async fn update_server_ip(window: Window, value: String, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).serverIp = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -25,7 +25,7 @@ pub async fn update_server_ip(window: Window, value: String, state: State<'_, Ar
 pub async fn update_self_ip(window: Window, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).selfIp = match local_ip() {Ok(ip) => ip.to_string(), Err(_) => "No network".into()};
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -33,7 +33,7 @@ pub async fn update_self_ip(window: Window, state: State<'_, Arc<Mutex<AppState>
 pub async fn update_session_id(window: Window, value: String, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).sessionId = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -41,7 +41,7 @@ pub async fn update_session_id(window: Window, value: String, state: State<'_, A
 pub async fn update_forwarding_id(window: Window, value: String, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).forwardingId = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -49,7 +49,7 @@ pub async fn update_forwarding_id(window: Window, value: String, state: State<'_
 pub async fn update_current_data_source(window: Window, value: String, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).currentDataSource = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -60,7 +60,7 @@ pub async fn add_alert(window: Window, value: Alert, state: State<'_, Arc<Mutex<
     (*inner_state.lock().await).alerts.pop();
   }
   (*inner_state.lock().await).alerts.insert(0, value);
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -68,12 +68,12 @@ pub async fn add_alert(window: Window, value: Alert, state: State<'_, Arc<Mutex<
 pub async fn update_feedsystem(window: Window, value: String, state: State<'_, Arc<Mutex<AppState>>>) -> Result<(), ()> {
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).feedsystem = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
 #[tauri::command]
-pub async fn get_feedsystem(window: Window, state: State<'_, Arc<Mutex<AppState>>>) -> Result<String, ()> {
+pub async fn get_feedsystem(state: State<'_, Arc<Mutex<AppState>>>) -> Result<String, ()> {
   let inner_state = Arc::clone(&state);
   let value = &(*inner_state.lock().await).feedsystem;
   return Ok(value.into());
@@ -84,7 +84,7 @@ pub async fn update_configs(window: Window, value: Vec<Config>, state: State<'_,
   println!("updating configs!");
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).configs = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -93,7 +93,7 @@ pub async fn update_active_config(window: Window, value: String, state: State<'_
   println!("updating active config to {}", value);
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).activeConfig = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -102,7 +102,7 @@ pub async fn update_abort_stages(window: Window, value: Vec<AbortStage>, state: 
   println!("updating abort stages!");
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).abortStages = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -111,7 +111,7 @@ pub async fn update_active_abort_stage(window: Window, value: String, state: Sta
   println!("updating active abort stage to {}", value);
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).activeAbortStage = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -120,7 +120,7 @@ pub async fn update_sequences(window: Window, value: Vec<Sequence>, state: State
   println!("updating sequences!");
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).sequences = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -129,7 +129,7 @@ pub async fn update_calibrations(window: Window, value: HashMap<String, f64>, st
   println!("updating calibrations!");
   let inner_state = Arc::clone(&state);
   (*inner_state.lock().await).calibrations = value;
-  window.emit_all("state", &*(inner_state.lock().await));
+  let _ = window.emit_all("state", &*(inner_state.lock().await));
   return Ok(());
 }
 
@@ -162,14 +162,6 @@ pub struct Sequence {
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
-pub struct Trigger {
-  pub name: String,
-  pub script: String,
-  pub active: bool,
-  pub condition: String
-}
-
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AbortStageMapping {
   pub valve_name: String,
   pub abort_stage: String,
@@ -185,6 +177,7 @@ pub struct AbortStage {
 
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[expect(non_snake_case, reason = "No harm in using snake case for this struct")]
 pub struct AppState {
   pub selfIp: String,
   pub selfPort: u16,

--- a/gui/src-tauri/src/utilities.rs
+++ b/gui/src-tauri/src/utilities.rs
@@ -1,7 +1,8 @@
 use std::net::Ipv4Addr;
 
 // UNSAFE CODE
-pub fn parseIpFromString(ip: &str) -> Ipv4Addr {
+#[expect(dead_code, reason = "Not currently used but may be useful in the future")]
+pub fn parse_ip_from_string(ip: &str) -> Ipv4Addr {
   let mut split_ip: [u8;4] = [0,0,0,0];
   let mut count = 0;
   for section in ip.split(".") {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.98.0"
 components = ["rustc", "cargo", "clippy", "rustfmt", "rust-analyzer"]

--- a/sam/src/adc.rs
+++ b/sam/src/adc.rs
@@ -4,15 +4,13 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ads114s06::ADC;
 use common::comm::{
     gpio::PinValue::{High, Low},
     sam::{ChannelType, SamDataPoint, SensorDataPoint},
-    ADCFamily, ADCKind,
+    ADCFamily,
     ADCKind::{SamRev3, SamRev4Flight, SamRev4FlightV2, SamRev4Gnd},
     SamRev3ADC, SamRev4FlightADC, SamRev4FlightV2ADC, SamRev4GndADC,
 };
-use jeflog::warn;
 
 use crate::{
     data::generate_data_point,
@@ -55,69 +53,68 @@ pub fn init_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
          */
 
         // mux register
-        adc.set_positive_input_channel(0); // change where needed
-        adc.set_negative_input_channel_to_aincom(); // change where needed
+        adc.set_positive_input_channel(0).unwrap(); // change where needed
+        adc.set_negative_input_channel_to_aincom().unwrap(); // change where needed
 
         // pga register
-        adc.set_programmable_conversion_delay(14);
-        adc.set_pga_gain(1); // change where needed
-        adc.disable_pga(); // change where needed
+        adc.set_programmable_conversion_delay(14).unwrap();
+        adc.set_pga_gain(1).unwrap(); // change where needed
+        adc.disable_pga().unwrap(); // change where needed
 
         // datarate register
-        adc.disable_global_chop();
-        adc.enable_internal_clock_disable_external();
-        adc.enable_continious_conversion_mode();
-        adc.enable_low_latency_filter();
-        adc.set_data_rate(4000.0);
+        adc.disable_global_chop().unwrap();
+        adc.enable_internal_clock_disable_external().unwrap();
+        adc.enable_continious_conversion_mode().unwrap();
+        adc.enable_low_latency_filter().unwrap();
+        adc.set_data_rate(4000.0).unwrap();
 
         // ref register
-        adc.disable_reference_monitor();
-        adc.enable_positive_reference_buffer();
-        adc.enable_negative_reference_buffer(); // change for RTDs
-                                                //adc.disable_negative_reference_buffer();
-        adc.set_ref_input_internal_2v5_ref(); // change for RTDs
-        adc.enable_internal_voltage_reference_on_pwr_down();
+        adc.disable_reference_monitor().unwrap();
+        adc.enable_positive_reference_buffer().unwrap();
+        adc.enable_negative_reference_buffer().unwrap(); // change for RTDs
+        adc.set_ref_input_internal_2v5_ref().unwrap(); // change for RTDs
+        adc.enable_internal_voltage_reference_on_pwr_down().unwrap();
 
         // idacmag register
-        adc.disable_pga_output_monitoring();
-        adc.open_low_side_pwr_switch();
-        adc.set_idac_magnitude(0); // change for RTDs
+        adc.disable_pga_output_monitoring().unwrap();
+        adc.open_low_side_pwr_switch().unwrap();
+        adc.set_idac_magnitude(0).unwrap(); // change for RTDs
 
         // idacmux register
-        adc.disable_idac1(); // change for RTD
-        adc.disable_idac2(); // change for RTD
+        adc.disable_idac1().unwrap(); // change for RTD
+        adc.disable_idac2().unwrap(); // change for RTD
 
         // vbias register
-        adc.disable_vbias();
+        adc.disable_vbias().unwrap();
 
         // system monitor register
-        adc.disable_system_monitoring(); // change for TCs
-        adc.disable_spi_timeout();
-        adc.disable_crc_byte();
-        adc.disable_status_byte();
+        adc.disable_system_monitoring().unwrap(); // change for TCs
+        adc.disable_spi_timeout().unwrap();
+        adc.disable_crc_byte().unwrap();
+        adc.disable_status_byte().unwrap();
 
         match adc.kind() {
             SamRev3(rev3_adc) => {
                 match rev3_adc {
                     SamRev3ADC::DiffSensors => {
-                        adc.enable_pga();
-                        adc.set_pga_gain(32);
-                        adc.set_positive_input_channel(5);
-                        adc.set_negative_input_channel(4);
+                        adc.enable_pga().unwrap();
+                        adc.set_pga_gain(32).unwrap();
+                        adc.set_positive_input_channel(5).unwrap();
+                        adc.set_negative_input_channel(4).unwrap();
                     }
 
                     SamRev3ADC::IValve => {
-                        adc.set_positive_input_channel(5);
+                        adc.set_positive_input_channel(5).unwrap();
                     }
 
                     SamRev3ADC::VValve => {
-                        adc.set_positive_input_channel(5);
+                        adc.set_positive_input_channel(5).unwrap();
                     }
 
                     SamRev3ADC::Tc1 | SamRev3ADC::Tc2 => {
                         // set up for initial PCB temp read
                         // handles enabling and setting PGA Gain
-                        adc.enable_internal_temp_sensor(1);
+                        adc.enable_internal_temp_sensor(1).unwrap();
                     }
 
                     _ => {} // no other changes needed for other ADCs
@@ -127,28 +124,28 @@ pub fn init_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
             SamRev4Gnd(rev4_gnd_adc) => {
                 match rev4_gnd_adc {
                     SamRev4GndADC::DiffSensors => {
-                        adc.enable_pga();
-                        adc.set_pga_gain(32);
-                        adc.set_positive_input_channel(0);
-                        adc.set_negative_input_channel(1);
+                        adc.enable_pga().unwrap();
+                        adc.set_pga_gain(32).unwrap();
+                        adc.set_positive_input_channel(0).unwrap();
+                        adc.set_negative_input_channel(1).unwrap();
                     }
 
                     SamRev4GndADC::IValve => {
-                        adc.set_positive_input_channel(2);
+                        adc.set_positive_input_channel(2).unwrap();
                     }
 
                     SamRev4GndADC::VValve => {
-                        adc.set_positive_input_channel(5);
+                        adc.set_positive_input_channel(5).unwrap();
                     }
 
                     SamRev4GndADC::Rtd1 | SamRev4GndADC::Rtd2 | SamRev4GndADC::Rtd3 => {
-                        adc.set_idac_magnitude(1000); // 1000 uA or 1 mA
-                        adc.enable_idac1_output_channel(0);
-                        adc.enable_idac2_output_channel(5);
-                        adc.set_positive_input_channel(1);
-                        adc.set_negative_input_channel(2);
-                        adc.disable_negative_reference_buffer();
-                        adc.set_ref_input_ref0();
+                        adc.set_idac_magnitude(1000).unwrap(); // 1000 uA or 1 mA
+                        adc.enable_idac1_output_channel(0).unwrap();
+                        adc.enable_idac2_output_channel(5).unwrap();
+                        adc.set_positive_input_channel(1).unwrap();
+                        adc.set_negative_input_channel(2).unwrap();
+                        adc.disable_negative_reference_buffer().unwrap();
+                        adc.set_ref_input_ref0().unwrap();
                     }
 
                     _ => {} // no other changes needed for other ADCs
@@ -158,20 +155,20 @@ pub fn init_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
             SamRev4Flight(rev4_flight_adc) => {
                 match rev4_flight_adc {
                     SamRev4FlightADC::DiffSensors => {
-                        adc.enable_pga();
-                        adc.set_pga_gain(32);
-                        adc.set_positive_input_channel(0);
-                        adc.set_negative_input_channel(1);
+                        adc.enable_pga().unwrap();
+                        adc.set_pga_gain(32).unwrap();
+                        adc.set_positive_input_channel(0).unwrap();
+                        adc.set_negative_input_channel(1).unwrap();
                     }
 
                     SamRev4FlightADC::Rtd1 | SamRev4FlightADC::Rtd2 | SamRev4FlightADC::Rtd3 => {
-                        adc.set_idac_magnitude(1000); // 1000 uA or 1 mA
-                        adc.enable_idac1_output_channel(0);
-                        adc.enable_idac2_output_channel(5);
-                        adc.set_positive_input_channel(1);
-                        adc.set_negative_input_channel(2);
-                        adc.disable_negative_reference_buffer();
-                        adc.set_ref_input_ref0();
+                        adc.set_idac_magnitude(1000).unwrap(); // 1000 uA or 1 mA
+                        adc.enable_idac1_output_channel(0).unwrap();
+                        adc.enable_idac2_output_channel(5).unwrap();
+                        adc.set_positive_input_channel(1).unwrap();
+                        adc.set_negative_input_channel(2).unwrap();
+                        adc.disable_negative_reference_buffer().unwrap();
+                        adc.set_ref_input_ref0().unwrap();
                     }
 
                     _ => {} // no other changes needed for other ADCs
@@ -181,20 +178,20 @@ pub fn init_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
             SamRev4FlightV2(rev4_flight_adc) => {
                 match rev4_flight_adc {
                     SamRev4FlightV2ADC::DiffSensors => {
-                        adc.enable_pga();
-                        adc.set_pga_gain(32);
-                        adc.set_positive_input_channel(0);
-                        adc.set_negative_input_channel(1);
+                        adc.enable_pga().unwrap();
+                        adc.set_pga_gain(32).unwrap();
+                        adc.set_positive_input_channel(0).unwrap();
+                        adc.set_negative_input_channel(1).unwrap();
                     }
 
                     SamRev4FlightV2ADC::Rtd1 | SamRev4FlightV2ADC::Rtd2 => {
-                        adc.set_idac_magnitude(1000); // 1000 uA or 1 mA
-                        adc.enable_idac1_output_channel(0);
-                        adc.enable_idac2_output_channel(5);
-                        adc.set_positive_input_channel(1);
-                        adc.set_negative_input_channel(2);
-                        adc.disable_negative_reference_buffer();
-                        adc.set_ref_input_ref0();
+                        adc.set_idac_magnitude(1000).unwrap(); // 1000 uA or 1 mA
+                        adc.enable_idac1_output_channel(0).unwrap();
+                        adc.enable_idac2_output_channel(5).unwrap();
+                        adc.set_positive_input_channel(1).unwrap();
+                        adc.set_negative_input_channel(2).unwrap();
+                        adc.disable_negative_reference_buffer().unwrap();
+                        adc.set_ref_input_ref0().unwrap();
                     }
 
                     _ => {} // no other changes needed for other ADCs
@@ -216,64 +213,64 @@ pub fn init_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
 // Commands each ADC to start collecting data
 pub fn start_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
     for adc in adcs.iter_mut() {
-        adc.spi_start_conversion();
+        let _ = adc.spi_start_conversion();
     }
 }
 
 pub fn reset_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
     for adc in adcs.iter_mut() {
         // stop collecting data
-        adc.spi_stop_conversion();
+        let _ = adc.spi_stop_conversion();
 
         // based on board and measurement type mux ADC to initial channels
         match adc.kind() {
             SamRev3(rev3_adc) => match rev3_adc {
                 SamRev3ADC::CurrentLoopPt => {
-                    adc.set_positive_input_channel(0);
+                    let _ = adc.set_positive_input_channel(0);
                 }
 
                 SamRev3ADC::DiffSensors => {
-                    adc.set_positive_input_channel(5);
-                    adc.set_negative_input_channel(4);
+                    let _ = adc.set_positive_input_channel(5);
+                    let _ = adc.set_negative_input_channel(4);
                 }
 
                 SamRev3ADC::IValve | SamRev3ADC::VValve => {
-                    adc.set_positive_input_channel(5);
+                    let _ = adc.set_positive_input_channel(5);
                 }
 
                 SamRev3ADC::IPower | SamRev3ADC::VPower => {
-                    adc.set_positive_input_channel(0);
+                    let _ = adc.set_positive_input_channel(0);
                 }
 
                 SamRev3ADC::Tc1 | SamRev3ADC::Tc2 => {
-                    adc.enable_internal_temp_sensor(1);
+                    let _ = adc.enable_internal_temp_sensor(1);
                 }
             },
 
             SamRev4Gnd(rev4_gnd_adc) => match rev4_gnd_adc {
                 SamRev4GndADC::CurrentLoopPt => {
-                    adc.set_positive_input_channel(0);
+                    let _ = adc.set_positive_input_channel(0);
                 }
 
                 SamRev4GndADC::DiffSensors => {
-                    adc.set_positive_input_channel(0);
-                    adc.set_negative_input_channel(1);
+                    let _ = adc.set_positive_input_channel(0);
+                    let _ = adc.set_negative_input_channel(1);
                 }
 
                 SamRev4GndADC::IValve => {
-                    adc.set_positive_input_channel(2);
+                    let _ = adc.set_positive_input_channel(2);
                 }
 
                 SamRev4GndADC::VValve => {
-                    adc.set_positive_input_channel(5);
+                    let _ = adc.set_positive_input_channel(5);
                 }
 
                 SamRev4GndADC::Rtd1 | SamRev4GndADC::Rtd2 | SamRev4GndADC::Rtd3 => {
-                    adc.enable_idac1_output_channel(0);
-                    adc.enable_idac2_output_channel(5);
-                    adc.set_positive_input_channel(1);
-                    adc.set_negative_input_channel(2);
-                    adc.set_ref_input_ref0();
+                    let _ = adc.enable_idac1_output_channel(0);
+                    let _ = adc.enable_idac2_output_channel(5);
+                    let _ = adc.set_positive_input_channel(1);
+                    let _ = adc.set_negative_input_channel(2);
+                    let _ = adc.set_ref_input_ref0();
                 }
             },
 
@@ -281,20 +278,20 @@ pub fn reset_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
                 SamRev4FlightADC::CurrentLoopPt
                 | SamRev4FlightADC::IValve
                 | SamRev4FlightADC::VValve => {
-                    adc.set_positive_input_channel(0);
+                    let _ = adc.set_positive_input_channel(0);
                 }
 
                 SamRev4FlightADC::DiffSensors => {
-                    adc.set_positive_input_channel(0);
-                    adc.set_negative_input_channel(1);
+                    let _ = adc.set_positive_input_channel(0);
+                    let _ = adc.set_negative_input_channel(1);
                 }
 
                 SamRev4FlightADC::Rtd1 | SamRev4FlightADC::Rtd2 | SamRev4FlightADC::Rtd3 => {
-                    adc.enable_idac1_output_channel(0);
-                    adc.enable_idac2_output_channel(5);
-                    adc.set_positive_input_channel(1);
-                    adc.set_negative_input_channel(2);
-                    adc.set_ref_input_ref0();
+                    let _ = adc.enable_idac1_output_channel(0);
+                    let _ = adc.enable_idac2_output_channel(5);
+                    let _ = adc.set_positive_input_channel(1);
+                    let _ = adc.set_negative_input_channel(2);
+                    let _ = adc.set_ref_input_ref0();
                 }
             },
 
@@ -302,20 +299,20 @@ pub fn reset_adcs(adcs: &mut [Box<dyn ADCFamily>]) {
                 SamRev4FlightV2ADC::CurrentLoopPt
                 | SamRev4FlightV2ADC::IValve
                 | SamRev4FlightV2ADC::VValve => {
-                    adc.set_positive_input_channel(0);
+                    let _ = adc.set_positive_input_channel(0);
                 }
 
                 SamRev4FlightV2ADC::DiffSensors => {
-                    adc.set_positive_input_channel(0);
-                    adc.set_negative_input_channel(1);
+                    let _ = adc.set_positive_input_channel(0);
+                    let _ = adc.set_negative_input_channel(1);
                 }
 
                 SamRev4FlightV2ADC::Rtd1 | SamRev4FlightV2ADC::Rtd2 => {
-                    adc.enable_idac1_output_channel(0);
-                    adc.enable_idac2_output_channel(5);
-                    adc.set_positive_input_channel(1);
-                    adc.set_negative_input_channel(2);
-                    adc.set_ref_input_ref0();
+                    let _ = adc.enable_idac1_output_channel(0);
+                    let _ = adc.enable_idac2_output_channel(5);
+                    let _ = adc.set_positive_input_channel(1);
+                    let _ = adc.set_negative_input_channel(2);
+                    let _ = adc.set_ref_input_ref0();
                 }
             },
 
@@ -334,31 +331,33 @@ pub fn poll_adcs(
     for iteration in 0..6 {
         for adc in adcs.iter_mut() {
             /* Not every ADC on a SAM board has 6 measurements so nothing is done
-            in the extra cases.
-            */
+            in the extra cases.*/
             let reached_max_rev3 = adc.kind() == SamRev3(SamRev3ADC::DiffSensors) && iteration > 2
-        || adc.kind() == SamRev3(SamRev3ADC::IPower) && iteration > 1
-        || adc.kind() == SamRev3(SamRev3ADC::VPower) && iteration > 4
-        || adc.kind() == SamRev3(SamRev3ADC::Tc1) && iteration > 3 // extra reading for PCB temp
-        || adc.kind() == SamRev3(SamRev3ADC::Tc2) && iteration > 3; // extra reading for PCB temp
+                || adc.kind() == SamRev3(SamRev3ADC::IPower) && iteration > 1
+                || adc.kind() == SamRev3(SamRev3ADC::VPower) && iteration > 4
+                || ((adc.kind() == SamRev3(SamRev3ADC::Tc1) // extra reading for PCB temp
+                        || adc.kind() == SamRev3(SamRev3ADC::Tc2)) // extra reading for PCB temp
+                        && iteration > 3);
 
             // same for rev4 flight and ground channel wise
-            let reached_max_rev4_gnd = adc.kind() == SamRev4Gnd(SamRev4GndADC::DiffSensors)
-                && iteration > 1
-                || adc.kind() == SamRev4Gnd(SamRev4GndADC::Rtd1) && iteration > 1
-                || adc.kind() == SamRev4Gnd(SamRev4GndADC::Rtd2) && iteration > 1
-                || adc.kind() == SamRev4Gnd(SamRev4GndADC::Rtd3) && iteration > 1;
+            let reached_max_rev4_gnd = (adc.kind() == SamRev4Gnd(SamRev4GndADC::DiffSensors)
+                || adc.kind() == SamRev4Gnd(SamRev4GndADC::Rtd1)
+                || adc.kind() == SamRev4Gnd(SamRev4GndADC::Rtd2)
+                || adc.kind() == SamRev4Gnd(SamRev4GndADC::Rtd3))
+                && iteration > 1;
 
-            let reached_max_rev4_flight =
-                adc.kind() == SamRev4Flight(SamRev4FlightADC::DiffSensors) && iteration > 1
-                    || adc.kind() == SamRev4Flight(SamRev4FlightADC::Rtd1) && iteration > 1
-                    || adc.kind() == SamRev4Flight(SamRev4FlightADC::Rtd2) && iteration > 1
-                    || adc.kind() == SamRev4Flight(SamRev4FlightADC::Rtd3) && iteration > 1;
+            let reached_max_rev4_flight = (adc.kind()
+                == SamRev4Flight(SamRev4FlightADC::DiffSensors)
+                || adc.kind() == SamRev4Flight(SamRev4FlightADC::Rtd1)
+                || adc.kind() == SamRev4Flight(SamRev4FlightADC::Rtd2)
+                || adc.kind() == SamRev4Flight(SamRev4FlightADC::Rtd3))
+                && iteration > 1;
 
-            let reached_max_rev4_flight_v2 =
-                adc.kind() == SamRev4FlightV2(SamRev4FlightV2ADC::DiffSensors) && iteration > 1
-                    || adc.kind() == SamRev4FlightV2(SamRev4FlightV2ADC::Rtd1) && iteration > 1
-                    || adc.kind() == SamRev4FlightV2(SamRev4FlightV2ADC::Rtd2) && iteration > 1;
+            let reached_max_rev4_flight_v2 = (adc.kind()
+                == SamRev4FlightV2(SamRev4FlightV2ADC::DiffSensors)
+                || adc.kind() == SamRev4FlightV2(SamRev4FlightV2ADC::Rtd1)
+                || adc.kind() == SamRev4FlightV2(SamRev4FlightV2ADC::Rtd2))
+                && iteration > 1;
 
             if reached_max_rev3
                 || reached_max_rev4_gnd
@@ -368,49 +367,15 @@ pub fn poll_adcs(
                 continue;
             }
 
-            /* Rev3 Thermocouple ADCs are the only ones that do not use the drdy pin.
-            If that is the case wait for 700 microseconds before attempting to get
-            data. Otherwise if there is a drdy pin, wait for it to go low which
-            indicates new data is available. If a certain amount of time has passed
-            and drdy has not gone low, move onto the next ADC to get data.
-             */
-
-            // let time = Instant::now();
-            // let mut go_to_next_adc: bool = false;
-            // if let Some(_) = adc.drdy_pin {
-            //   loop {
-            //     // since drdy pin exists here I could just unwrap() on check_drdy
-            //     // as it is guaranteed to return a PinValue
-            //     if adc.check_drdy() == Some(Low) {
-            //       break;
-            //     } else if Instant::now() - time > Duration::from_micros(1000) {
-            //       go_to_next_adc = true;
-            //       break;
-            //     }
-            //   }
-            // } else {
-            //   thread::sleep(Duration::from_micros(700)); // delay for TCs since
-            // they dont have drdy pins }
-
-            // if go_to_next_adc {
-            //   continue; // cannot communicate with current ADC
-            // }
-
             // poll for data ready
             let time = Instant::now();
             let mut go_to_next_adc: bool = false;
 
-            // make sure that this new version works
             loop {
                 if let Some(pin_val) = adc.check_drdy() {
                     if pin_val == Low {
                         break;
                     } else if Instant::now() - time > ADC_DRDY_TIMEOUT {
-                        // Commenting it out for Tymur :)
-                        // warn!(
-                        //   "ADC {:?} drdy not pulled low... going to next ADC",
-                        //   adc.kind
-                        // );
                         go_to_next_adc = true;
                         break;
                     }
@@ -434,35 +399,37 @@ pub fn poll_adcs(
                             match rev3_adc {
                                 SamRev3ADC::CurrentLoopPt => {
                                     let data = adc.calc_diff_measurement_offset(raw_data);
-                                    adc.set_positive_input_channel((iteration + 1) % 6);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 6);
 
                                     data
                                 }
 
                                 SamRev3ADC::IValve => {
                                     let data = adc.calc_diff_measurement_offset(raw_data);
-                                    adc.set_positive_input_channel(5 - ((iteration + 1) % 6));
+                                    let _ =
+                                        adc.set_positive_input_channel(5 - ((iteration + 1) % 6));
 
                                     data
                                 }
 
                                 SamRev3ADC::VValve => {
                                     let data = adc.calc_diff_measurement_offset(raw_data) * 11.0;
-                                    adc.set_positive_input_channel(5 - ((iteration + 1) % 6));
+                                    let _ =
+                                        adc.set_positive_input_channel(5 - ((iteration + 1) % 6));
 
                                     data
                                 }
 
                                 SamRev3ADC::IPower => {
                                     let data = adc.calc_diff_measurement_offset(raw_data);
-                                    adc.set_positive_input_channel((iteration + 1) % 2);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 2);
 
                                     data
                                 }
 
                                 SamRev3ADC::VPower => {
                                     let data = adc.calc_diff_measurement_offset(raw_data) * 11.0;
-                                    adc.set_positive_input_channel((iteration + 1) % 5);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 5);
 
                                     data
                                 }
@@ -474,14 +441,14 @@ pub fn poll_adcs(
                                         / 1000.0; // gain of 32
 
                                     if iteration == 0 {
-                                        adc.set_positive_input_channel(3);
-                                        adc.set_negative_input_channel(2);
+                                        let _ = adc.set_positive_input_channel(3);
+                                        let _ = adc.set_negative_input_channel(2);
                                     } else if iteration == 1 {
-                                        adc.set_positive_input_channel(1);
-                                        adc.set_negative_input_channel(0);
+                                        let _ = adc.set_positive_input_channel(1);
+                                        let _ = adc.set_negative_input_channel(0);
                                     } else if iteration == 2 {
-                                        adc.set_positive_input_channel(5);
-                                        adc.set_negative_input_channel(4);
+                                        let _ = adc.set_positive_input_channel(5);
+                                        let _ = adc.set_negative_input_channel(4);
                                     }
 
                                     data
@@ -494,23 +461,20 @@ pub fn poll_adcs(
                                 SamRev3ADC::Tc1 => {
                                     if iteration == 0 {
                                         // ambient temp
-                                        //let data = adc.calc_diff_measurement(raw_data) * 1000.0;
-                                        let data = ((raw_data as i32) as f64)
-                                            * (2.5 / ((1 << 15) as f64))
-                                            * 1000.0;
+                                        let data =
+                                            (raw_data as f64) * (2.5 / ((1 << 15) as f64)) * 1000.0;
                                         let ambient_temp = data * 0.403 - 26.987;
                                         // I want it to panic if this don't work :)
                                         ambient_temps.as_mut().unwrap()[0] = ambient_temp;
 
-                                        adc.disable_system_monitoring();
-                                        adc.enable_pga();
-                                        adc.set_pga_gain(32);
-                                        adc.set_positive_input_channel(5);
-                                        adc.set_negative_input_channel(4);
+                                        let _ = adc.disable_system_monitoring();
+                                        let _ = adc.enable_pga();
+                                        let _ = adc.set_pga_gain(32);
+                                        let _ = adc.set_positive_input_channel(5);
+                                        let _ = adc.set_negative_input_channel(4);
                                         continue; // I don't want to return
                                                   // ambient temp
                                     } else {
-                                        //let data = adc.calc_diff_measurement(raw_data);
                                         let data =
                                             (raw_data as f64) * (2.5 / ((1 << 15) as f64)) / 0.032;
                                         let ambient_temp = ambient_temps.as_ref().unwrap()[0];
@@ -519,14 +483,14 @@ pub fn poll_adcs(
                                             as f64;
 
                                         if iteration == 1 {
-                                            adc.set_positive_input_channel(3);
-                                            adc.set_negative_input_channel(2);
+                                            let _ = adc.set_positive_input_channel(3);
+                                            let _ = adc.set_negative_input_channel(2);
                                         } else if iteration == 2 {
-                                            adc.set_positive_input_channel(1);
-                                            adc.set_negative_input_channel(0);
+                                            let _ = adc.set_positive_input_channel(1);
+                                            let _ = adc.set_negative_input_channel(0);
                                         } else if iteration == 3 {
                                             // handles enabling and setting PGA gain
-                                            adc.enable_internal_temp_sensor(1);
+                                            let _ = adc.enable_internal_temp_sensor(1);
                                         }
 
                                         temp
@@ -536,22 +500,19 @@ pub fn poll_adcs(
                                 SamRev3ADC::Tc2 => {
                                     if iteration == 0 {
                                         // ambient temp
-                                        //let data = adc.calc_diff_measurement(raw_data) * 1000.0;
-                                        let data = ((raw_data as i32) as f64)
-                                            * (2.5 / ((1 << 15) as f64))
-                                            * 1000.0;
+                                        let data =
+                                            (raw_data as f64) * (2.5 / ((1 << 15) as f64)) * 1000.0;
                                         let ambient_temp = data * 0.403 - 26.987;
                                         ambient_temps.as_mut().unwrap()[1] = ambient_temp;
 
-                                        adc.disable_system_monitoring();
-                                        adc.enable_pga();
-                                        adc.set_pga_gain(32);
-                                        adc.set_positive_input_channel(5);
-                                        adc.set_negative_input_channel(4);
+                                        let _ = adc.disable_system_monitoring();
+                                        let _ = adc.enable_pga();
+                                        let _ = adc.set_pga_gain(32);
+                                        let _ = adc.set_positive_input_channel(5);
+                                        let _ = adc.set_negative_input_channel(4);
                                         continue; // I don't want to return
                                                   // ambient temp
                                     } else {
-                                        //let data = adc.calc_diff_measurement(raw_data);
                                         let data =
                                             (raw_data as f64) * (2.5 / ((1 << 15) as f64)) / 0.032;
                                         let ambient_temp = ambient_temps.as_ref().unwrap()[1];
@@ -560,14 +521,14 @@ pub fn poll_adcs(
                                             as f64;
 
                                         if iteration == 1 {
-                                            adc.set_positive_input_channel(3);
-                                            adc.set_negative_input_channel(2);
+                                            let _ = adc.set_positive_input_channel(3);
+                                            let _ = adc.set_negative_input_channel(2);
                                         } else if iteration == 2 {
-                                            adc.set_positive_input_channel(1);
-                                            adc.set_negative_input_channel(0);
+                                            let _ = adc.set_positive_input_channel(1);
+                                            let _ = adc.set_negative_input_channel(0);
                                         } else if iteration == 3 {
                                             // handles enabling and setting PGA gain
-                                            adc.enable_internal_temp_sensor(1);
+                                            let _ = adc.enable_internal_temp_sensor(1);
                                         }
 
                                         temp
@@ -580,7 +541,7 @@ pub fn poll_adcs(
                             match rev4_gnd_adc {
                                 SamRev4GndADC::CurrentLoopPt => {
                                     let data = adc.calc_diff_measurement(raw_data) * 2.0;
-                                    adc.set_positive_input_channel((iteration + 1) % 6);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 6);
 
                                     data
                                 }
@@ -602,11 +563,11 @@ pub fn poll_adcs(
                                     }
 
                                     if iteration == 1 {
-                                        adc.set_positive_input_channel(1);
+                                        let _ = adc.set_positive_input_channel(1);
                                     } else if iteration == 3 {
-                                        adc.set_positive_input_channel(0);
+                                        let _ = adc.set_positive_input_channel(0);
                                     } else if iteration == 5 {
-                                        adc.set_positive_input_channel(2);
+                                        let _ = adc.set_positive_input_channel(2);
                                     }
 
                                     data
@@ -614,7 +575,8 @@ pub fn poll_adcs(
 
                                 SamRev4GndADC::VValve => {
                                     let data = adc.calc_diff_measurement(raw_data) * 11.0;
-                                    adc.set_positive_input_channel(5 - ((iteration + 1) % 6)); // flipped
+                                    let _ =
+                                        adc.set_positive_input_channel(5 - ((iteration + 1) % 6));
 
                                     data
                                 }
@@ -625,11 +587,11 @@ pub fn poll_adcs(
                                         / 1000.0;
 
                                     if iteration == 0 {
-                                        adc.set_positive_input_channel(2);
-                                        adc.set_negative_input_channel(3);
+                                        let _ = adc.set_positive_input_channel(2);
+                                        let _ = adc.set_negative_input_channel(3);
                                     } else if iteration == 1 {
-                                        adc.set_positive_input_channel(0);
-                                        adc.set_negative_input_channel(1);
+                                        let _ = adc.set_positive_input_channel(0);
+                                        let _ = adc.set_negative_input_channel(1);
                                     }
 
                                     data
@@ -638,23 +600,16 @@ pub fn poll_adcs(
                                 SamRev4GndADC::Rtd1 | SamRev4GndADC::Rtd2 | SamRev4GndADC::Rtd3 => {
                                     let rtd_resistance =
                                         adc.calc_four_wire_rtd_resistance(raw_data, 2500.0);
-                                    // let temp = if rtd_resistance <= 100.0 {
-                                    //   0.0014 * rtd_resistance.powi(2) + 2.2521 * rtd_resistance
-                                    //     - 239.04
-                                    // } else {
-                                    //   0.0014 * rtd_resistance.powi(2) + 2.1814 * rtd_resistance
-                                    //     - 230.07
-                                    // };
                                     let temp = get_rtd_temp(rtd_resistance);
 
                                     if iteration == 0 {
-                                        adc.set_positive_input_channel(3);
-                                        adc.set_negative_input_channel(4);
-                                        adc.set_ref_input_ref1();
+                                        let _ = adc.set_positive_input_channel(3);
+                                        let _ = adc.set_negative_input_channel(4);
+                                        let _ = adc.set_ref_input_ref1();
                                     } else if iteration == 1 {
-                                        adc.set_positive_input_channel(1);
-                                        adc.set_negative_input_channel(2);
-                                        adc.set_ref_input_ref0();
+                                        let _ = adc.set_positive_input_channel(1);
+                                        let _ = adc.set_negative_input_channel(2);
+                                        let _ = adc.set_ref_input_ref0();
                                     }
 
                                     temp
@@ -666,7 +621,7 @@ pub fn poll_adcs(
                             match rev4_flight_adc {
                                 SamRev4FlightADC::CurrentLoopPt => {
                                     let data = adc.calc_diff_measurement(raw_data) * 2.0;
-                                    adc.set_positive_input_channel((iteration + 1) % 6);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 6);
 
                                     data
                                 }
@@ -688,11 +643,11 @@ pub fn poll_adcs(
                                     }
 
                                     if iteration == 1 {
-                                        adc.set_positive_input_channel(1);
+                                        let _ = adc.set_positive_input_channel(1);
                                     } else if iteration == 3 {
-                                        adc.set_positive_input_channel(2);
+                                        let _ = adc.set_positive_input_channel(2);
                                     } else if iteration == 5 {
-                                        adc.set_positive_input_channel(0);
+                                        let _ = adc.set_positive_input_channel(0);
                                     }
 
                                     data
@@ -700,7 +655,7 @@ pub fn poll_adcs(
 
                                 SamRev4FlightADC::VValve => {
                                     let data = adc.calc_diff_measurement(raw_data) * 11.0;
-                                    adc.set_positive_input_channel((iteration + 1) % 6);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 6);
 
                                     data
                                 }
@@ -709,11 +664,11 @@ pub fn poll_adcs(
                                     let data = adc.calc_diff_measurement(raw_data);
 
                                     if iteration == 0 {
-                                        adc.set_positive_input_channel(2);
-                                        adc.set_negative_input_channel(3);
+                                        let _ = adc.set_positive_input_channel(2);
+                                        let _ = adc.set_negative_input_channel(3);
                                     } else if iteration == 1 {
-                                        adc.set_positive_input_channel(0);
-                                        adc.set_negative_input_channel(1);
+                                        let _ = adc.set_positive_input_channel(0);
+                                        let _ = adc.set_negative_input_channel(1);
                                     }
 
                                     data
@@ -724,23 +679,16 @@ pub fn poll_adcs(
                                 | SamRev4FlightADC::Rtd3 => {
                                     let rtd_resistance =
                                         adc.calc_four_wire_rtd_resistance(raw_data, 2500.0);
-                                    // let temp = if rtd_resistance <= 100.0 {
-                                    //   0.0014 * rtd_resistance.powi(2) + 2.2521 * rtd_resistance
-                                    //     - 239.04
-                                    // } else {
-                                    //   0.0014 * rtd_resistance.powi(2) + 2.1814 * rtd_resistance
-                                    //     - 230.07
-                                    // };
                                     let temp = get_rtd_temp(rtd_resistance);
 
                                     if iteration == 0 {
-                                        adc.set_positive_input_channel(3);
-                                        adc.set_negative_input_channel(4);
-                                        adc.set_ref_input_ref1();
+                                        let _ = adc.set_positive_input_channel(3);
+                                        let _ = adc.set_negative_input_channel(4);
+                                        let _ = adc.set_ref_input_ref1();
                                     } else if iteration == 1 {
-                                        adc.set_positive_input_channel(1);
-                                        adc.set_negative_input_channel(2);
-                                        adc.set_ref_input_ref0();
+                                        let _ = adc.set_positive_input_channel(1);
+                                        let _ = adc.set_negative_input_channel(2);
+                                        let _ = adc.set_ref_input_ref0();
                                     }
 
                                     temp
@@ -752,7 +700,7 @@ pub fn poll_adcs(
                             match rev4_flight_adc {
                                 SamRev4FlightV2ADC::CurrentLoopPt => {
                                     let data = adc.calc_diff_measurement(raw_data) * 2.0;
-                                    adc.set_positive_input_channel((iteration + 1) % 6);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 6);
 
                                     data
                                 }
@@ -774,11 +722,11 @@ pub fn poll_adcs(
                                     }
 
                                     if iteration == 1 {
-                                        adc.set_positive_input_channel(1);
+                                        let _ = adc.set_positive_input_channel(1);
                                     } else if iteration == 3 {
-                                        adc.set_positive_input_channel(2);
+                                        let _ = adc.set_positive_input_channel(2);
                                     } else if iteration == 5 {
-                                        adc.set_positive_input_channel(0);
+                                        let _ = adc.set_positive_input_channel(0);
                                     }
 
                                     data
@@ -786,7 +734,7 @@ pub fn poll_adcs(
 
                                 SamRev4FlightV2ADC::VValve => {
                                     let data = adc.calc_diff_measurement(raw_data) * 11.0;
-                                    adc.set_positive_input_channel((iteration + 1) % 6);
+                                    let _ = adc.set_positive_input_channel((iteration + 1) % 6);
 
                                     data
                                 }
@@ -795,11 +743,11 @@ pub fn poll_adcs(
                                     let data = adc.calc_diff_measurement(raw_data);
 
                                     if iteration == 0 {
-                                        adc.set_positive_input_channel(2);
-                                        adc.set_negative_input_channel(3);
+                                        let _ = adc.set_positive_input_channel(2);
+                                        let _ = adc.set_negative_input_channel(3);
                                     } else if iteration == 1 {
-                                        adc.set_positive_input_channel(0);
-                                        adc.set_negative_input_channel(1);
+                                        let _ = adc.set_positive_input_channel(0);
+                                        let _ = adc.set_negative_input_channel(1);
                                     }
 
                                     data
@@ -808,23 +756,16 @@ pub fn poll_adcs(
                                 SamRev4FlightV2ADC::Rtd1 | SamRev4FlightV2ADC::Rtd2 => {
                                     let rtd_resistance =
                                         adc.calc_four_wire_rtd_resistance(raw_data, 2500.0);
-                                    // let temp = if rtd_resistance <= 100.0 {
-                                    //   0.0014 * rtd_resistance.powi(2) + 2.2521 * rtd_resistance
-                                    //     - 239.04
-                                    // } else {
-                                    //   0.0014 * rtd_resistance.powi(2) + 2.1814 * rtd_resistance
-                                    //     - 230.07
-                                    // };
                                     let temp = get_rtd_temp(rtd_resistance);
 
                                     if iteration == 0 {
-                                        adc.set_positive_input_channel(3);
-                                        adc.set_negative_input_channel(4);
-                                        adc.set_ref_input_ref1();
+                                        let _ = adc.set_positive_input_channel(3);
+                                        let _ = adc.set_negative_input_channel(4);
+                                        let _ = adc.set_ref_input_ref1();
                                     } else if iteration == 1 {
-                                        adc.set_positive_input_channel(1);
-                                        adc.set_negative_input_channel(2);
-                                        adc.set_ref_input_ref0();
+                                        let _ = adc.set_positive_input_channel(1);
+                                        let _ = adc.set_negative_input_channel(2);
+                                        let _ = adc.set_ref_input_ref0();
                                     }
 
                                     temp
@@ -885,12 +826,10 @@ pub fn read_onboard_adc(channel: usize, rail_path: &str) -> (f64, ChannelType) {
                 } else {
                     return (f64::NAN, ChannelType::RailCurrent);
                 }
+            } else if channel == 0 || channel == 1 || channel == 3 {
+                return (f64::NAN, ChannelType::RailVoltage);
             } else {
-                if channel == 0 || channel == 1 || channel == 3 {
-                    return (f64::NAN, ChannelType::RailVoltage);
-                } else {
-                    return (f64::NAN, ChannelType::RailCurrent);
-                }
+                return (f64::NAN, ChannelType::RailCurrent);
             }
         }
     };
@@ -961,16 +900,16 @@ pub fn read_onboard_adc(channel: usize, rail_path: &str) -> (f64, ChannelType) {
 
             if *SAM_VERSION == SamVersion::Rev4Ground {
                 if channel == 0 || channel == 2 || channel == 4 {
-                    return (f64::NAN, ChannelType::RailVoltage);
+                    (f64::NAN, ChannelType::RailVoltage)
                 } else {
-                    return (f64::NAN, ChannelType::RailCurrent);
+                    (f64::NAN, ChannelType::RailCurrent)
                 }
             } else {
                 // rev4 flight
                 if channel == 0 || channel == 1 || channel == 3 {
-                    return (f64::NAN, ChannelType::RailVoltage);
+                    (f64::NAN, ChannelType::RailVoltage)
                 } else {
-                    return (f64::NAN, ChannelType::RailCurrent);
+                    (f64::NAN, ChannelType::RailCurrent)
                 }
             }
         }

--- a/servo/src/interface/display.rs
+++ b/servo/src/interface/display.rs
@@ -199,7 +199,7 @@ struct SensorDatapoint {
     rolling_average: f64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct SystemDatapoint {
     device_name: Option<String>,
     ip: Option<IpAddr>,
@@ -249,22 +249,6 @@ impl TuiData {
         match self.selected_source {
             TelemetrySource::Umbilical => &self.umbilical,
             TelemetrySource::Radio => &self.radio,
-        }
-    }
-}
-
-impl Default for SystemDatapoint {
-    fn default() -> Self {
-        SystemDatapoint {
-            device_name: None,
-            ip: None,
-            port: None,
-            time_since_update: None,
-            update_rate: None,
-            packet_size: None,
-            ping: None,
-            cpu_usage: None,
-            mem_usage: None,
         }
     }
 }
@@ -333,7 +317,7 @@ async fn update_information(tui_data: &mut TuiData, shared: &Shared, system: &mu
                     let _ = real_name.split_off(real_name.len() - 2);
 
                     if let Some(pair) = pane.valves.get_mut(&real_name) {
-                        let ref mut valve_datapoint = pair.value;
+                        let valve_datapoint = &mut pair.value;
                         valve_datapoint.current = reading.value;
 
                         if !valve_datapoint.knows_current {
@@ -351,7 +335,7 @@ async fn update_information(tui_data: &mut TuiData, shared: &Shared, system: &mu
                     let _ = real_name.split_off(real_name.len() - 2);
 
                     if let Some(pair) = pane.valves.get_mut(&real_name) {
-                        let ref mut valve_datapoint = pair.value;
+                        let valve_datapoint = &mut pair.value;
                         valve_datapoint.voltage = reading.value;
 
                         if !valve_datapoint.knows_voltage {
@@ -617,7 +601,7 @@ pub async fn display(shared: Shared) -> io::Result<()> {
 
     // Attempt to restore terminal
     if let Err(error) = restore_terminal(&mut terminal) {
-        return Err(io::Error::new(io::ErrorKind::Other, error.to_string()));
+        return Err(io::Error::other(error.to_string()));
     }
 
     Ok(())

--- a/servo/src/interface/display.rs
+++ b/servo/src/interface/display.rs
@@ -493,16 +493,14 @@ fn display_round(
         // async requirements.
         let poll_res = crossterm::event::poll(Duration::from_millis(0));
 
-        if poll_res.is_err() {
-            println!("Input polling failed : ");
-            println!("{}", poll_res.unwrap_err());
+        if let Err(poll_err) = poll_res {
+            eprintln!("Input polling failed : {poll_err}");
             return false;
         }
-        if poll_res.unwrap() {
+        if let Ok(true) = poll_res {
             let read_res = event::read();
-            if read_res.is_err() {
-                println!("Input reading failed : ");
-                println!("{}", read_res.unwrap_err());
+            if let Err(read_err) = read_res {
+                eprintln!("Input reading failed : {read_err}");
                 return false;
             }
             // If a quit command is recieved, return false to signal to quit
@@ -973,24 +971,22 @@ fn draw_valves(f: &mut Frame, area: Rect, pane: &TelemetryPaneData, selected_sou
         // coding is based on fixed thresholds set for voltage and current
         // independently.
         let d_v = datapoint.voltage - datapoint.rolling_voltage_average;
-        let d_v_style: Style;
-        if d_v.abs() < 0.1 {
-            d_v_style = normal_style;
+        let d_v_style: Style = if d_v.abs() < 0.1 {
+            normal_style
         } else if d_v > 0.0 {
-            d_v_style = normal_style.fg(Color::Green);
+            normal_style.fg(Color::Green)
         } else {
-            d_v_style = normal_style.fg(Color::Red);
-        }
+            normal_style.fg(Color::Red)
+        };
 
         let d_i: f64 = datapoint.current - datapoint.rolling_current_average;
-        let d_i_style: Style;
-        if d_i.abs() < 0.025 {
-            d_i_style = normal_style;
+        let d_i_style: Style = if d_i.abs() < 0.025 {
+            normal_style
         } else if d_i > 0.0 {
-            d_i_style = normal_style.fg(Color::Green);
+            normal_style.fg(Color::Green)
         } else {
-            d_i_style = normal_style.fg(Color::Red);
-        }
+            normal_style.fg(Color::Red)
+        };
 
         let voltage_rows = if datapoint.knows_voltage {
             [
@@ -1106,7 +1102,6 @@ fn draw_sensors(f: &mut Frame, area: Rect, pane: &TelemetryPaneData, selected_so
         // And color code the change based on it's magnitude and sign
         // (increasing / decreasing)
         let d_v = datapoint.measurement.value - datapoint.rolling_average;
-        let d_v_style: Style;
 
         // As values can have vastly differing units, the color code change is 1%
         // of the value, with a minimum change threshold of 0.01 if the value is
@@ -1118,13 +1113,13 @@ fn draw_sensors(f: &mut Frame, area: Rect, pane: &TelemetryPaneData, selected_so
         // significant enough to highlight. Since sensors have a bigger potential
         // range, a flat delta threshold is a bad idea as it would require
         // configuration.
-        if d_v.abs() / value_magnitude < 0.01 {
-            d_v_style = data_style;
+        let d_v_style: Style = if d_v.abs() / value_magnitude < 0.01 {
+            data_style
         } else if d_v > 0.0 {
-            d_v_style = normal_style.fg(Color::Green);
+            normal_style.fg(Color::Green)
         } else {
-            d_v_style = normal_style.fg(Color::Red);
-        }
+            normal_style.fg(Color::Red)
+        };
 
         rows.push(
             Row::new(vec![

--- a/servo/src/server/flight.rs
+++ b/servo/src/server/flight.rs
@@ -353,7 +353,7 @@ pub fn receive_vehicle_state(shared: &Shared) -> impl Future<Output = io::Result
                                 &frame_buffer[..datagram_size],
                                 schema,
                             )
-                            .map_err(|error| format_radio_decode_error(error))
+                            .map_err(format_radio_decode_error)
                         }
                     };
 
@@ -444,7 +444,7 @@ fn telemetry_source_from_control(
             }
         }
 
-        let next = (current as usize).saturating_add(cmsg_align(header.cmsg_len as usize));
+        let next = (current as usize).saturating_add(cmsg_align(header.cmsg_len));
         if next >= end {
             break;
         }

--- a/servo/src/server/routes/data.rs
+++ b/servo/src/server/routes/data.rs
@@ -333,7 +333,7 @@ pub async fn export(
                     // currently, if there is no data here, the column is empty.
                     // we may want to change this.
                     if let Some(reading) = reading {
-                        content += &format!("{:.3}", &reading.value);
+                        content += &format!("{:.3}", reading.value);
                     }
                 }
 

--- a/servo/src/server/telemetry.rs
+++ b/servo/src/server/telemetry.rs
@@ -2,11 +2,10 @@ use std::{
     collections::HashSet,
     fmt::{self, Display, Formatter},
     sync::Arc,
-    time::Duration,
 };
 
 use common::comm::{
-    include_in_radio_telemetry, sam::Unit, NodeMapping, SensorType, VehicleState,
+    include_in_radio_telemetry, NodeMapping, SensorType, VehicleState,
     VehicleStateDecompressionSchema,
 };
 use tokio::{
@@ -15,9 +14,10 @@ use tokio::{
 };
 
 /// Distinguishes the two telemetry paths Servo can ingest from flight.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum TelemetrySource {
     /// Telemetry received directly over the Ethernet umbilical.
+    #[default]
     Umbilical,
     /// Telemetry received over the TEL radio link.
     Radio,
@@ -38,12 +38,6 @@ impl TelemetrySource {
             Self::Umbilical => "VehicleSnapshots",
             Self::Radio => "RadioTelemetry",
         }
-    }
-}
-
-impl Default for TelemetrySource {
-    fn default() -> Self {
-        Self::Umbilical
     }
 }
 
@@ -81,9 +75,8 @@ pub struct LiveTelemetry {
     pub packet_size: Arc<(Mutex<Option<usize>>, Notify)>,
 }
 
-impl LiveTelemetry {
-    /// Creates the live state container for one telemetry source.
-    pub fn new() -> Self {
+impl Default for LiveTelemetry {
+    fn default() -> Self {
         Self {
             vehicle: Arc::new((Mutex::new(VehicleState::new()), Notify::new())),
             last_vehicle_state: Arc::new((Mutex::new(None), Notify::new())),
@@ -94,7 +87,7 @@ impl LiveTelemetry {
 }
 
 /// Shared state for both telemetry sources.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TelemetryState {
     /// Live state for umbilical telemetry.
     pub umbilical: LiveTelemetry,
@@ -105,10 +98,7 @@ pub struct TelemetryState {
 impl TelemetryState {
     /// Creates live state for both telemetry sources.
     pub fn new() -> Self {
-        Self {
-            umbilical: LiveTelemetry::new(),
-            radio: LiveTelemetry::new(),
-        }
+        Self::default()
     }
 
     /// Returns the live state container for the requested telemetry source.
@@ -209,6 +199,8 @@ pub async fn update_live_telemetry(
 
 #[cfg(test)]
 mod tests {
+    use common::comm::sam::Unit;
+
     use super::*;
 
     fn mapping(text_id: &str, board_id: &str, sensor_type: SensorType) -> NodeMapping {

--- a/servo/src/tool/deploy.rs
+++ b/servo/src/tool/deploy.rs
@@ -193,16 +193,13 @@ impl fmt::Display for Repository {
 pub fn locate_cache() -> anyhow::Result<PathBuf> {
     task!("Locating cache directory.");
 
-    let cache_path;
-
-    if cfg!(target_os = "macos") {
-        cache_path = PathBuf::from(env::var("HOME")?).join("Library/Caches/servo");
+    let cache_path = if cfg!(target_os = "macos") {
+        PathBuf::from(env::var("HOME")?).join("Library/Caches/servo")
     } else if cfg!(target_os = "windows") {
-        cache_path = PathBuf::from(env::var("LOCALAPPDATA")?).join("servo");
-    // cache_display_path = "%LOCALAPPDATA%\\servo";
+        PathBuf::from(env::var("LOCALAPPDATA")?).join("servo")
     } else {
-        cache_path = PathBuf::from("/var/cache/servo");
-    }
+        PathBuf::from("/var/cache/servo")
+    };
 
     fs::create_dir_all(&cache_path)?;
     pass!("Located cache at {}.", cache_path.to_string_lossy());

--- a/utility/src/main.rs
+++ b/utility/src/main.rs
@@ -1,16 +1,11 @@
 use std::{
-    collections::{HashMap, HashSet},
     fs::File,
     io::{BufReader, Read},
     path::PathBuf,
 };
 
 use clap::Parser;
-use common::comm::{
-    bms::{Bms, Bus},
-    fc_sensors::{Barometer, FcSensors, Imu, Vector},
-    CompositeValveState,
-};
+use common::comm::fc_sensors::Imu;
 use csv::Writer;
 use postcard::from_bytes;
 use serde_json::Value;
@@ -31,6 +26,10 @@ struct TimestampedImu {
 
 /// Enum to represent either type of entry
 #[derive(Clone, Debug)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Utility is run on a machine with non-constrained resources"
+)]
 enum Entry {
     VehicleState(TimestampedVehicleState),
     Imu(TimestampedImu),
@@ -216,7 +215,7 @@ fn build_columns(entries: &[Entry]) -> Vec<String> {
                 serde_json::to_value(&ts.state).expect("Failed to serialize VehicleState to JSON")
             }
             Entry::Imu(ts) => {
-                serde_json::to_value(&ts.state).expect("Failed to serialize Imu to JSON")
+                serde_json::to_value(ts.state).expect("Failed to serialize Imu to JSON")
             }
         };
 
@@ -294,7 +293,7 @@ fn write_csv_dynamic(
             ),
             Entry::Imu(ts) => (
                 ts.timestamp,
-                serde_json::to_value(&ts.state).expect("Failed to serialize Imu to JSON"),
+                serde_json::to_value(ts.state).expect("Failed to serialize Imu to JSON"),
             ),
         };
 


### PR DESCRIPTION
## Overview

Add a `config.toml` file that forces all build warnings to be errors, and clean up any remaining warnings. By forcing all build warnings to be errors, we can enforce good software development practices as any newly introduced warnings get promoted to errors and will need to be handled before merging.

Additionally, change the precommit config file to use `cargo clippy` instead of `cargo check`. This forces all code in `luna` to practice idiomatic rust and follow a consistent style. To make rust-analyzer as helpful as possible, enable the appropriate flags to match the clippy command in the precommit config file. To force people to use the same toolchain linter, fix the toolchain to the latest stable toolchain (1.98).

## Verification Evidence

Latest CI actions pass.